### PR TITLE
Consume atscript annotation parameters as arrays

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -30,7 +30,7 @@ export class Container {
         keys = new Array(parameters.length);
 
         for(i = 0, ii = parameters.length; i < ii; ++i){
-          keys[i] = parameters[i].is;
+          keys[i] = parameters[i].is || parameters[i][0];
         }
       }
 

--- a/test/container.spec.js
+++ b/test/container.spec.js
@@ -62,6 +62,25 @@ describe('container', () => {
 
       expect(app.logger).toEqual(jasmine.any(Logger));
     });
+
+    it('uses static parameters property as array (AtScript)', function() {
+      class Logger {}
+
+      class App {
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      App.parameters = [[Logger]]; //Note: Normally provided by the AtScript compiler.
+
+      var container = new Container();
+      container.supportAtScript();
+
+      var app = container.get(App);
+
+      expect(app.logger).toEqual(jasmine.any(Logger));
+    });
   });
 
   describe('registration', () => {


### PR DESCRIPTION
Current traceur-compiler return annotation parameters as array of arrays. Let's consume this output.

See #15 