### PR TITLE
fix(container) throw when key is undefined or null

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -98,7 +98,12 @@ export class Container {
   * @param {Object} [key] The key that identifies the dependency at resolution time; usually a constructor function.
   */
   autoRegister(fn, key){
-    var registration = Metadata.on(fn).first(Registration, true);
+    var registration;
+
+    if (fn === null || fn === undefined)
+      throw new Error('fn cannot be null or undefined.')
+
+    registration = Metadata.on(fn).first(Registration, true);
     
     if(registration){
       registration.register(this, key || fn, fn);
@@ -141,6 +146,9 @@ export class Container {
   get(key) {
     var entry;
 
+    if (key === null || key === undefined)
+      throw new Error('key cannot be null or undefined.');
+
     if(key instanceof Resolver){
       return key.get(this);
     }
@@ -173,7 +181,12 @@ export class Container {
   * @return {Object[]} Returns an array of the resolved instances.
   */
   getAll(key) {
-    var entry = this.entries.get(key);
+    var entry;
+
+    if (key === null || key === undefined)
+      throw new Error('key cannot be null or undefined.');
+
+    entry = this.entries.get(key);
 
     if(entry !== undefined){
       return entry.map(x => x(this));
@@ -195,6 +208,9 @@ export class Container {
   * @return {Boolean} Returns true if the key has been registred; false otherwise.
   */
   hasHandler(key, checkParent=false) {
+    if (key === null || key === undefined)
+      throw new Error('key cannot be null or undefined.');
+
     return this.entries.has(key) 
       || (checkParent && this.parent && this.parent.hasHandler(key, checkParent));
   }
@@ -243,7 +259,12 @@ export class Container {
   }
 
   getOrCreateEntry(key) {
-    var entry = this.entries.get(key);
+    var entry;
+
+    if (key === null || key === undefined)
+      throw new Error('key cannot be null or undefined.');
+
+    entry = this.entries.get(key);
 
     if (entry === undefined) {
       entry = [];

--- a/test/container.spec.js
+++ b/test/container.spec.js
@@ -84,6 +84,37 @@ describe('container', () => {
   });
 
   describe('registration', () => {
+    it('asserts keys are defined', () => {
+      var container = new Container();
+
+      expect(() => container.get(null)).toThrow();
+      expect(() => container.get(undefined)).toThrow();
+
+      expect(() => container.get(null)).toThrow();
+      expect(() => container.get(undefined)).toThrow();
+
+      expect(() => container.registerInstance(null, {})).toThrow();
+      expect(() => container.registerInstance(undefined, {})).toThrow();
+
+      expect(() => container.registerSingleton(null)).toThrow();
+      expect(() => container.registerSingleton(undefined)).toThrow();
+
+      expect(() => container.registerTransient(null)).toThrow();
+      expect(() => container.registerTransient(undefined)).toThrow();
+
+      expect(() => container.autoRegister(null)).toThrow();
+      expect(() => container.autoRegister(undefined)).toThrow();
+
+      expect(() => container.autoRegisterAll([null])).toThrow();
+      expect(() => container.autoRegisterAll([undefined])).toThrow();
+
+      expect(() => container.registerHandler(null)).toThrow();
+      expect(() => container.registerHandler(undefined)).toThrow();
+
+      expect(() => container.hasHandler(null)).toThrow();
+      expect(() => container.hasHandler(undefined)).toThrow();
+    });
+
     it('automatically configures as singleton', () => {
       class Logger {}
 


### PR DESCRIPTION
Early detection of invalid registration calls improves the development experience.

Fixes #17