### PR TITLE
fix(dependency-injection): Use correct import for core-js

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import {Metadata} from 'aurelia-metadata';
 import {AggregateError} from 'aurelia-logging';
 import {Resolver, ClassActivator} from './metadata';

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 
 /**
 * Used to allow functions/classes to indicate that they should be registered as transients with the container.


### PR DESCRIPTION
We were previously using `import core from core-js` which generates d.ts that do not match the corejs d.ts. This is now updated to `import * as core 'core-js'`, which resolves TypeScript compilation warnings.

closes aurelia/framework#177