### PR TITLE
feat(all): Add an API to register an alias name for an existing key

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -86,6 +86,20 @@ export class Container {
   }
 
   /**
+  * Registers an alias for another key with the container.
+  *
+  * @method registerAlias
+  * @param {Object} alias The alias name of a key.
+  * @param {Object} original The original key that is already registered or can be auto registered with the container.
+  */
+  registerAlias(alias : any, original : any) : void {
+    if (alias === original){
+      return;
+    }
+    this.registerHandler(alias, x => x.get(original));
+  }
+
+  /**
   * Registers a type (constructor function) by inspecting its registration annotations. If none are found, then the default singleton registration is used.
   *
   * @method autoRegister

--- a/test/container.spec.js
+++ b/test/container.spec.js
@@ -308,6 +308,19 @@ describe('container', () => {
       expect(app2.logger).toBe(instance);
     });
 
+    it('configures alias via api', () => {
+      class Logger {}
+
+      var container = new Container();
+      var instance = new Logger();
+      container.registerInstance(Logger, instance);
+      container.registerAlias('logger', Logger);
+
+      var logger = container.get('logger');
+
+      expect(logger).toBe(instance);
+    });
+
     it('configures custom via api', () => {
       class Logger {}
 


### PR DESCRIPTION
I use aurelia dependency injection in one of my project, which allows other developers to extend the core functionalities and use the DI container in very flexible ways. I found in a few circumstances that it would be useful to register an alias for a key, so an instance or a singleton could be accessed in multiple ways. Currently I use `registerHandler()` to achieve this, but I wonder if you would also find this useful and accept `registerAlias()` as a public API.

I tried to follow the contribution guidelines, however the build process in the latest commit is broken. I still created this PR since the code changes are minimal, and I would like to see if you are interested at all.