### PR TITLE
Allow injections with class inheritence

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -415,12 +415,25 @@ export class Container {
   _createInvocationHandler(fn: Function): InvocationHandler {
     let dependencies;
 
-    if (typeof fn.inject === 'function') {
-      dependencies = fn.inject();
-    } else if (fn.inject === undefined) {
+    if (fn.inject === undefined) {
       dependencies = metadata.getOwn(metadata.paramTypes, fn) || _emptyParameters;
     } else {
-      dependencies = fn.inject;
+      function getDependencies(f) {
+        if (!f.hasOwnProperty('inject')) {
+          return [];
+        }
+        if (typeof f.inject === 'function') {
+          return f.inject();
+        } else {
+          return f.inject;
+        }
+      }
+      dependencies = [];
+      let ctor = fn;
+      while (typeof ctor === 'function') {
+        dependencies.push(...getDependencies(ctor));
+        ctor = Object.getPrototypeOf(ctor);
+      }
     }
 
     let invoker = metadata.getOwn(metadata.invoker, fn)

--- a/test/container.spec.js
+++ b/test/container.spec.js
@@ -49,6 +49,69 @@ describe('container', () => {
     });
   });
 
+  describe('inheritence', function() {
+    class Logger {}
+    class Service {}
+
+    it('loads dependencies for the parent class', function() {
+      class ParentApp {
+        static inject() { return [Logger]; }
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      class ChildApp extends ParentApp {
+        constructor(...rest) {
+          super(...rest);
+        }
+      }
+
+      let container = new Container();
+      let app = container.get(ChildApp);
+      expect(app.logger).toEqual(jasmine.any(Logger));
+    });
+
+    it('loads dependencies for the child class', function() {
+      class ParentApp {
+      }
+
+      class ChildApp extends ParentApp {
+        static inject() { return [Service]; }
+        constructor(service, ...rest) {
+          super(...rest);
+          this.service = service;
+        }
+      }
+
+      let container = new Container();
+      let app = container.get(ChildApp);
+      expect(app.service).toEqual(jasmine.any(Service));
+    });
+
+    it('loads dependencies for both classes', function() {
+      class ParentApp {
+        static inject() { return [Logger]; }
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      class ChildApp extends ParentApp {
+        static inject() { return [Service]; }
+        constructor(service, ...rest) {
+          super(...rest);
+          this.service = service;
+        }
+      }
+
+      let container = new Container();
+      let app = container.get(ChildApp);
+      expect(app.service).toEqual(jasmine.any(Service));
+      expect(app.logger).toEqual(jasmine.any(Logger));
+    });
+  });
+
   describe('registration', () => {
     it('asserts keys are defined', () => {
       let container = new Container();


### PR DESCRIPTION
This PR allows you to use injections with class inheritance.

If you have a super class
```
import {Logger} from 'path/logger';
import {Cache} from 'path/cache';

@inject(Logger, Cache)
class Parent {
  constructor(logger, cache) {
    this.logger = logger;
    this.cache = cache;
  }
}
```
the dependencies need to be injected in the child class as well:
```
import {Logger} from 'adjusted/path/logger';
import {Cache} from 'adjusted/path/cache';
import {Service} from 'other/path/service';

@inject(Service, Logger, Cache)
class Child extends Parent {
  constructor(service, logger, cache) {
    super(logger, cache);
    this.service = service;
  }
}
```

With this PR that is no longer needed, just provide the extra required injection:
```
import {Service} from 'other/path/service';

@inject(Service)
class Child extends Parent {
  constructor(service, ...args) {
    super(...args);
    this.service = service;
  }
}
```
