### PR TITLE
feat(inject-properties): allow injection into properties

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -63,9 +63,9 @@ function injectProperties(container, fn, instance) {
     for (let property in dependencies) {
       instance[property] = container.get(dependencies[property]);
     }
-  }
-  if (instance.postConstruct !== undefined) {
-    instance.postConstruct();
+    if (instance.postConstruct !== undefined) {
+      instance.postConstruct();
+    }
   }
   return instance;
 }

--- a/src/container.js
+++ b/src/container.js
@@ -76,43 +76,92 @@ function invokeWithDynamicDependencies(container, fn, staticDependencies, dynami
     args = args.concat(dynamicDependencies);
   }
 
-  return Reflect.construct(fn, args);
+  let instance = Reflect.construct(fn, args);
+  if (fn.injectProperties !== undefined) {
+    let injectProperties = fn.injectProperties;
+    for (let property in injectProperties) {
+      instance[property] = container.get(injectProperties[property]);
+    }
+  }
+  return instance;
 }
 
 let classInvokers = {
   [0]: {
     invoke(container, Type) {
-      return new Type();
+      let instance = new Type();
+      if (Type.injectProperties !== undefined) {
+        let injectProperties = Type.injectProperties;
+        for (let property in injectProperties) {
+          instance[property] = container.get(injectProperties[property]);
+        }
+      }
+      return instance;
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [1]: {
     invoke(container, Type, deps) {
-      return new Type(container.get(deps[0]));
+      let instance = new Type(container.get(deps[0]));
+      if (Type.injectProperties !== undefined) {
+        let injectProperties = Type.injectProperties;
+        for (let property in injectProperties) {
+          instance[property] = container.get(injectProperties[property]);
+        }
+      }
+      return instance;
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [2]: {
     invoke(container, Type, deps) {
-      return new Type(container.get(deps[0]), container.get(deps[1]));
+      let instance = new Type(container.get(deps[0]), container.get(deps[1]));
+      if (Type.injectProperties !== undefined) {
+        let injectProperties = Type.injectProperties;
+        for (let property in injectProperties) {
+          instance[property] = container.get(injectProperties[property]);
+        }
+      }
+      return instance;
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [3]: {
     invoke(container, Type, deps) {
-      return new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]));
+      let instance = new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]));
+      if (Type.injectProperties !== undefined) {
+        let injectProperties = Type.injectProperties;
+        for (let property in injectProperties) {
+          instance[property] = container.get(injectProperties[property]);
+        }
+      }
+      return instance;
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [4]: {
     invoke(container, Type, deps) {
-      return new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]), container.get(deps[3]));
+      let instance = new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]), container.get(deps[3]));
+      if (Type.injectProperties !== undefined) {
+        let injectProperties = Type.injectProperties;
+        for (let property in injectProperties) {
+          instance[property] = container.get(injectProperties[property]);
+        }
+      }
+      return instance;
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [5]: {
     invoke(container, Type, deps) {
-      return new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]), container.get(deps[3]), container.get(deps[4]));
+      let instance = new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]), container.get(deps[3]), container.get(deps[4]));
+      if (Type.injectProperties !== undefined) {
+        let injectProperties = Type.injectProperties;
+        for (let property in injectProperties) {
+          instance[property] = container.get(injectProperties[property]);
+        }
+      }
+      return instance;
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },

--- a/src/container.js
+++ b/src/container.js
@@ -1,6 +1,7 @@
 import {metadata} from 'aurelia-metadata';
 import {AggregateError} from 'aurelia-pal';
 import {resolver, StrategyResolver} from './resolvers';
+import {injectProperties} from './injection';
 
 const badKeyError = 'key/value cannot be null or undefined. Are you trying to inject/register something that doesn\'t exist with DI?';
 export const _emptyParameters = Object.freeze([]);
@@ -76,92 +77,43 @@ function invokeWithDynamicDependencies(container, fn, staticDependencies, dynami
     args = args.concat(dynamicDependencies);
   }
 
-  let instance = Reflect.construct(fn, args);
-  if (fn.injectProperties !== undefined) {
-    let injectProperties = fn.injectProperties;
-    for (let property in injectProperties) {
-      instance[property] = container.get(injectProperties[property]);
-    }
-  }
-  return instance;
+  return injectProperties(container, fn, Reflect.construct(fn, args));
 }
 
 let classInvokers = {
   [0]: {
     invoke(container, Type) {
-      let instance = new Type();
-      if (Type.injectProperties !== undefined) {
-        let injectProperties = Type.injectProperties;
-        for (let property in injectProperties) {
-          instance[property] = container.get(injectProperties[property]);
-        }
-      }
-      return instance;
+      return injectProperties(container, Type, new Type());
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [1]: {
     invoke(container, Type, deps) {
-      let instance = new Type(container.get(deps[0]));
-      if (Type.injectProperties !== undefined) {
-        let injectProperties = Type.injectProperties;
-        for (let property in injectProperties) {
-          instance[property] = container.get(injectProperties[property]);
-        }
-      }
-      return instance;
+      return injectProperties(container, Type, new Type(container.get(deps[0])));
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [2]: {
     invoke(container, Type, deps) {
-      let instance = new Type(container.get(deps[0]), container.get(deps[1]));
-      if (Type.injectProperties !== undefined) {
-        let injectProperties = Type.injectProperties;
-        for (let property in injectProperties) {
-          instance[property] = container.get(injectProperties[property]);
-        }
-      }
-      return instance;
+      return injectProperties(container, Type, new Type(container.get(deps[0]), container.get(deps[1])));
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [3]: {
     invoke(container, Type, deps) {
-      let instance = new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]));
-      if (Type.injectProperties !== undefined) {
-        let injectProperties = Type.injectProperties;
-        for (let property in injectProperties) {
-          instance[property] = container.get(injectProperties[property]);
-        }
-      }
-      return instance;
+      return injectProperties(container, Type, new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2])));
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [4]: {
     invoke(container, Type, deps) {
-      let instance = new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]), container.get(deps[3]));
-      if (Type.injectProperties !== undefined) {
-        let injectProperties = Type.injectProperties;
-        for (let property in injectProperties) {
-          instance[property] = container.get(injectProperties[property]);
-        }
-      }
-      return instance;
+      return injectProperties(container, Type, new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]), container.get(deps[3])));
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [5]: {
     invoke(container, Type, deps) {
-      let instance = new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]), container.get(deps[3]), container.get(deps[4]));
-      if (Type.injectProperties !== undefined) {
-        let injectProperties = Type.injectProperties;
-        for (let property in injectProperties) {
-          instance[property] = container.get(injectProperties[property]);
-        }
-      }
-      return instance;
+      return injectProperties(container, Type, new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]), container.get(deps[3]), container.get(deps[4])));
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },

--- a/src/container.js
+++ b/src/container.js
@@ -63,8 +63,8 @@ function injectProperties(container, fn, instance) {
     for (let property in dependencies) {
       instance[property] = container.get(dependencies[property]);
     }
-    if (instance.postConstruct !== undefined) {
-      instance.postConstruct();
+    if (instance.afterConstructor !== undefined) {
+      instance.afterConstructor();
     }
   }
   return instance;

--- a/src/container.js
+++ b/src/container.js
@@ -1,7 +1,6 @@
 import {metadata} from 'aurelia-metadata';
 import {AggregateError} from 'aurelia-pal';
 import {resolver, StrategyResolver} from './resolvers';
-import {injectProperties} from './injection';
 
 const badKeyError = 'key/value cannot be null or undefined. Are you trying to inject/register something that doesn\'t exist with DI?';
 export const _emptyParameters = Object.freeze([]);
@@ -53,6 +52,22 @@ export class InvocationHandler {
       ? injectProperties(container, this.fn, this.invoker.invokeWithDynamicDependencies(container, this.fn, this.dependencies, dynamicDependencies))
       : injectProperties(container, this.fn, this.invoker.invoke(container, this.fn, this.dependencies));
   }
+}
+
+/**
+* Injects property dependencies if the conventional `injectProperties` is defined.
+*/
+function injectProperties(container, fn, instance) {
+  if (fn.injectProperties !== undefined) {
+    let dependencies = fn.injectProperties;
+    for (let property in dependencies) {
+      instance[property] = container.get(dependencies[property]);
+    }
+  }
+  if (instance.postConstruct !== undefined) {
+    instance.postConstruct();
+  }
+  return instance;
 }
 
 /**

--- a/src/container.js
+++ b/src/container.js
@@ -50,8 +50,8 @@ export class InvocationHandler {
   */
   invoke(container: Container, dynamicDependencies?: any[]): any {
     return dynamicDependencies !== undefined
-      ? this.invoker.invokeWithDynamicDependencies(container, this.fn, this.dependencies, dynamicDependencies)
-      : this.invoker.invoke(container, this.fn, this.dependencies);
+      ? injectProperties(container, this.fn, this.invoker.invokeWithDynamicDependencies(container, this.fn, this.dependencies, dynamicDependencies))
+      : injectProperties(container, this.fn, this.invoker.invoke(container, this.fn, this.dependencies));
   }
 }
 
@@ -77,43 +77,43 @@ function invokeWithDynamicDependencies(container, fn, staticDependencies, dynami
     args = args.concat(dynamicDependencies);
   }
 
-  return injectProperties(container, fn, Reflect.construct(fn, args));
+  return Reflect.construct(fn, args);
 }
 
 let classInvokers = {
   [0]: {
     invoke(container, Type) {
-      return injectProperties(container, Type, new Type());
+      return new Type();
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [1]: {
     invoke(container, Type, deps) {
-      return injectProperties(container, Type, new Type(container.get(deps[0])));
+      return new Type(container.get(deps[0]));
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [2]: {
     invoke(container, Type, deps) {
-      return injectProperties(container, Type, new Type(container.get(deps[0]), container.get(deps[1])));
+      return new Type(container.get(deps[0]), container.get(deps[1]));
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [3]: {
     invoke(container, Type, deps) {
-      return injectProperties(container, Type, new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2])));
+      return new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]));
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [4]: {
     invoke(container, Type, deps) {
-      return injectProperties(container, Type, new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]), container.get(deps[3])));
+      return new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]), container.get(deps[3]));
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },
   [5]: {
     invoke(container, Type, deps) {
-      return injectProperties(container, Type, new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]), container.get(deps[3]), container.get(deps[4])));
+      return new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]), container.get(deps[3]), container.get(deps[4]));
     },
     invokeWithDynamicDependencies: invokeWithDynamicDependencies
   },

--- a/src/injection.js
+++ b/src/injection.js
@@ -13,14 +13,23 @@ export function autoinject(potentialTarget?: any): any {
 }
 
 /**
-* Decorator: Specifies the dependencies that should be injected by the DI Container into the decoratored class/function.
+* Decorator: Specifies the dependencies that should be injected by the DI Container into the decorated class/function/property.
 */
 export function inject(...rest: any[]): any {
   return function(target, key, descriptor) {
-    // if it's true then we injecting rest into function and not Class constructor
-    if (descriptor) {
-      const fn = descriptor.value;
-      fn.inject = rest;
+    // if it's defined then we are injecting rest into function/property and not Class constructor
+    if (descriptor !== undefined) {
+      // if it's true then we are injecting rest into function and not property
+      if (descriptor.configurable) {
+        const fn = descriptor.value;
+        fn.inject = rest;
+      } else {
+        if (target.constructor.injectProperties === undefined) {
+          target.constructor.injectProperties = {};
+        }
+        target.constructor.injectProperties[key] = rest[0];
+        descriptor.writable = true;
+      }
     } else {
       target.inject = rest;
     }

--- a/src/injection.js
+++ b/src/injection.js
@@ -37,11 +37,11 @@ export function inject(...rest: any[]): any {
 }
 
 export function injectProperties(container, fn, instance) {
-    if (fn.injectProperties !== undefined) {
-      let dependencies = fn.injectProperties;
-      for (let property in dependencies) {
-        instance[property] = container.get(dependencies[property]);
-      }
+  if (fn.injectProperties !== undefined) {
+    let dependencies = fn.injectProperties;
+    for (let property in dependencies) {
+      instance[property] = container.get(dependencies[property]);
     }
-    return instance;
+  }
+  return instance;
 }

--- a/src/injection.js
+++ b/src/injection.js
@@ -35,3 +35,13 @@ export function inject(...rest: any[]): any {
     }
   };
 }
+
+export function injectProperties(container, fn, instance) {
+    if (fn.injectProperties !== undefined) {
+      let dependencies = fn.injectProperties;
+      for (let property in dependencies) {
+        instance[property] = container.get(dependencies[property]);
+      }
+    }
+    return instance;
+}

--- a/src/injection.js
+++ b/src/injection.js
@@ -12,7 +12,7 @@ export function autoinject(potentialTarget?: any, potentialKey?: any): any {
     } else if (descriptor === undefined) {
       // we are injecting into Class property
       if (target.constructor.injectProperties === undefined) {
-        target.constructor.injectProperties = {};
+        target.constructor.injectProperties = Object.create(null);
       }
       target.constructor.injectProperties[key] = metadata.getOwn("design:type", target, key);
     }
@@ -34,7 +34,7 @@ export function inject(...rest: any[]): any {
         fn.inject = rest;
       } else {
         if (target.constructor.injectProperties === undefined) {
-          target.constructor.injectProperties = {};
+          target.constructor.injectProperties = Object.create(null);
         }
         target.constructor.injectProperties[key] = rest[0];
         // we need the property to be writable to inject the dependency

--- a/src/invokers.js
+++ b/src/invokers.js
@@ -66,7 +66,14 @@ export class FactoryInvoker {
       args[i] = container.get(dependencies[i]);
     }
 
-    return fn.apply(undefined, args);
+    let instance = fn.apply(undefined, args);
+    if (fn.injectProperties !== undefined) {
+      let injectProperties = fn.injectProperties;
+      for (let property in injectProperties) {
+        instance[property] = container.get(injectProperties[property]);
+      }
+    }
+    return instance;
   }
 
   /**
@@ -89,7 +96,14 @@ export class FactoryInvoker {
       args = args.concat(dynamicDependencies);
     }
 
-    return fn.apply(undefined, args);
+    let instance = fn.apply(undefined, args);
+    if (fn.injectProperties !== undefined) {
+      let injectProperties = fn.injectProperties;
+      for (let property in injectProperties) {
+        instance[property] = container.get(injectProperties[property]);
+      }
+    }
+    return instance;
   }
 }
 

--- a/src/invokers.js
+++ b/src/invokers.js
@@ -1,5 +1,4 @@
 import {metadata} from 'aurelia-metadata';
-import {injectProperties} from './injection';
 
 /**
 * Decorator: Specifies a custom Invoker for the decorated item.
@@ -67,7 +66,7 @@ export class FactoryInvoker {
       args[i] = container.get(dependencies[i]);
     }
 
-    return injectProperties(container, fn, fn.apply(undefined, args));
+    return fn.apply(undefined, args);
   }
 
   /**
@@ -90,7 +89,7 @@ export class FactoryInvoker {
       args = args.concat(dynamicDependencies);
     }
 
-    return injectProperties(container, fn, fn.apply(undefined, args));
+    return fn.apply(undefined, args);
   }
 }
 

--- a/src/invokers.js
+++ b/src/invokers.js
@@ -1,4 +1,5 @@
 import {metadata} from 'aurelia-metadata';
+import {injectProperties} from './injection';
 
 /**
 * Decorator: Specifies a custom Invoker for the decorated item.
@@ -66,14 +67,7 @@ export class FactoryInvoker {
       args[i] = container.get(dependencies[i]);
     }
 
-    let instance = fn.apply(undefined, args);
-    if (fn.injectProperties !== undefined) {
-      let injectProperties = fn.injectProperties;
-      for (let property in injectProperties) {
-        instance[property] = container.get(injectProperties[property]);
-      }
-    }
-    return instance;
+    return injectProperties(container, fn, fn.apply(undefined, args));
   }
 
   /**
@@ -96,14 +90,7 @@ export class FactoryInvoker {
       args = args.concat(dynamicDependencies);
     }
 
-    let instance = fn.apply(undefined, args);
-    if (fn.injectProperties !== undefined) {
-      let injectProperties = fn.injectProperties;
-      for (let property in injectProperties) {
-        instance[property] = container.get(injectProperties[property]);
-      }
-    }
-    return instance;
+    return injectProperties(container, fn, fn.apply(undefined, args));
   }
 }
 

--- a/test/container.spec.js
+++ b/test/container.spec.js
@@ -49,6 +49,22 @@ describe('container', () => {
     });
   });
 
+  describe('inject-properties', function() {
+    class Logger {}
+
+    it('uses static injectProperties', function() {
+      class App {}
+
+      App.injectProperties = {
+        logger: Logger
+      };
+
+      let container = new Container();
+      let app = container.get(App);
+      expect(app.logger).toEqual(jasmine.any(Logger));
+    });
+  });
+
   describe('inheritence', function() {
     class Logger {}
     class Service {}

--- a/test/container.spec.js
+++ b/test/container.spec.js
@@ -50,7 +50,9 @@ describe('container', () => {
   });
 
   describe('inject-properties', function() {
-    class Logger {}
+    class Logger {
+      check = false;
+    }
 
     it('uses static injectProperties', function() {
       class App {}
@@ -62,6 +64,22 @@ describe('container', () => {
       let container = new Container();
       let app = container.get(App);
       expect(app.logger).toEqual(jasmine.any(Logger));
+    });
+
+    it('calls afterConstructor hook', function() {
+      class App {
+        afterConstructor() {
+          this.logger.check = true;
+        }
+      }
+
+      App.injectProperties = {
+        logger: Logger
+      };
+
+      let container = new Container();
+      let app = container.get(App);
+      expect(app.logger.check).toBe(true);
     });
   });
 


### PR DESCRIPTION
This PR allows the injection of dependencies into instance properties, lifting the constructor from being the dependency bearer and decoupling child classes from parent dependencies.

The implementation follows the _Convention over configuration_ paradigm, assuming the presence of a static `injectProperties` enumeration of `property: Type` to satisfy dependencies. For example, having a class like this:

```javascript
import {Router} from "aurelia-router";

export class MyClass {

    static injectProperties = {
        router: Router
    };

}
```
the container will produce an instance of `MyClass` with the current `Router` available in the `router` property.

This PR allows also the use of `@inject()` on properties like this:
```javascript
import {inject} from "aurelia-dependency-injection";
import {Router} from "aurelia-router";

export class MyClass {

    @inject(Router)
    router;

}
```

**Further improvements**
- [x] Like on other languages DI implementations (e.g. Java CDI), injection into properties cannot make the dependencies available inside the constructor; an improvement could be invoking a conventional `postConstruct` function after the injection, or a `@postConstruct` decorator on a function to be called on the instance after injection.
- [x] Having `@autoinject` allowed to be used onto properties and infer types from metadata.
