### PR TITLE
feat(resolver): added decorators for lazy, all, optional, parent, factory and newInstance

### DIFF
--- a/src/injection.js
+++ b/src/injection.js
@@ -17,6 +17,19 @@ export function autoinject(potentialTarget?: any): any {
 */
 export function inject(...rest: any[]): any {
   return function(target, key, descriptor) {
+    // handle when used as a parameter
+    if (typeof descriptor === 'number' && rest.length === 1) {
+      let params = target.inject;
+      if (typeof params === 'function') {
+        throw new Error('Decorator inject cannot be used with "inject()".  Please use an array instead.');
+      }
+      if (!params) {
+        params = metadata.getOwn(metadata.paramTypes, target).concat();
+        target.inject = params;
+      }
+      params[descriptor] = rest[0];
+      return;
+    }
     // if it's true then we injecting rest into function and not Class constructor
     if (descriptor) {
       const fn = descriptor.value;

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -300,3 +300,88 @@ export class NewInstance {
     return new NewInstance(key);
   }
 }
+
+function getDeocratorDependencies(target, name) {
+  let dependencies = target.inject;
+  if (typeof dependencies === 'function') {
+    throw new Error('Decorator ' + name + ' cannot be used with "inject()".  Please use an array instead.');
+  }
+  if (!dependencies) {
+    dependencies = metadata.getOwn(metadata.paramTypes, target).concat();
+    target.inject = dependencies;
+  }
+  return dependencies;
+}
+
+/**
+* Decorator: Specifies the dependency should be lazy loaded
+*/
+export function lazy(keyValue: any) {
+  return function(target, key, index) {
+    let params = getDeocratorDependencies(target, 'lazy');
+    params[index] = Lazy.of(keyValue);
+  };
+}
+
+/**
+* Decorator: Specifies the dependency should load all instances of the given key.
+*/
+export function all(keyValue: any) {
+  return function(target, key, index) {
+    let params = getDeocratorDependencies(target, 'all');
+    params[index] = All.of(keyValue);
+  };
+}
+
+/**
+* Decorator: Specifies the dependency as optional
+*/
+export function optional(checkParentOrTarget: boolean = true) {
+  let deco = function(checkParent: boolean) {
+    return function(target, key, index) {
+      let params = getDeocratorDependencies(target, 'optional');
+      params[index] = Optional.of(params[index], checkParent);
+    };
+  };
+  if (typeof checkParentOrTarget === 'boolean') {
+    return deco(checkParentOrTarget);
+  }
+  return deco(true);
+}
+
+/**
+* Decorator: Specifies the dependency to look at the parent container for resolution
+*/
+export function parent(target, key, index) {
+  let params = getDeocratorDependencies(target, 'parent');
+  params[index] = Parent.of(params[index]);
+}
+
+/**
+* Decorator: Specifies the dependency to create a factory method, that can accept optional arguments
+*/
+export function factory(keyValue: any) {
+  return function(target, key, index) {
+    let params = getDeocratorDependencies(target, 'factory');
+    params[index] = Factory.of(keyValue);
+  };
+}
+
+/**
+* Decorator: Specifies the dependency as a new instance
+*/
+export function newInstance(asKeyOrTarget?: any) {
+  let deco = function(asKey?: any) {
+    return function(target, key, index) {
+      let params = getDeocratorDependencies(target, 'newInstance');
+      params[index] = NewInstance.of(params[index]);
+      if (!!asKey) {
+        params[index].as(asKey);
+      }
+    };
+  };
+  if (arguments.length === 1) {
+    return deco(asKeyOrTarget);
+  }
+  return deco();
+}

--- a/test/container.spec.js
+++ b/test/container.spec.js
@@ -1,6 +1,6 @@
 import './setup';
 import {Container} from '../src/container';
-import {Lazy, All, Optional, Parent, Factory} from '../src/resolvers';
+import {Lazy, All, Optional, Parent, Factory, lazy, all, optional, parent, factory} from '../src/resolvers';
 import {transient, singleton} from '../src/registrations';
 import {inject} from '../src/injection';
 import {decorators} from 'aurelia-metadata';
@@ -509,6 +509,26 @@ describe('container', () => {
 
           expect(logger()).toEqual(jasmine.any(Logger));
         });
+
+        it('provides a function which, when called, will return the instance using decorator', () => {
+          class Logger {}
+
+          class App1 {
+            static inject = [Logger];
+            constructor(getLogger) {
+              this.getLogger = getLogger;
+            }
+          }
+
+          lazy(Logger)(App1, null, 0);
+
+          let container = new Container();
+          let app1 = container.get(App1);
+
+          let logger = app1.getLogger;
+
+          expect(logger()).toEqual(jasmine.any(Logger));
+        });
       });
 
       describe('All', ()=> {
@@ -536,6 +556,55 @@ describe('container', () => {
           expect(app.loggers[0]).toEqual(jasmine.any(VerboseLogger));
           expect(app.loggers[1]).toEqual(jasmine.any(Logger));
         });
+
+        it('resolves all matching dependencies as an array of instances using decorator', () => {
+          class LoggerBase {}
+
+          class VerboseLogger extends LoggerBase {}
+
+          class Logger extends LoggerBase {}
+
+          class App {
+            static inject = [LoggerBase];
+            constructor(loggers) {
+              this.loggers = loggers;
+            }
+          }
+
+          all(LoggerBase)(App, null, 0);
+
+          let container = new Container();
+          container.registerSingleton(LoggerBase, VerboseLogger);
+          container.registerTransient(LoggerBase, Logger);
+          let app = container.get(App);
+
+          expect(app.loggers).toEqual(jasmine.any(Array));
+          expect(app.loggers.length).toBe(2);
+          expect(app.loggers[0]).toEqual(jasmine.any(VerboseLogger));
+          expect(app.loggers[1]).toEqual(jasmine.any(Logger));
+        });
+      });
+
+      describe('inject as param decorator', ()=> {
+        it('resolves a matching dependency using the inject decorator', () => {
+          class Logger {}
+
+          class App1 {
+            static inject = [Logger];
+            constructor(logger) {
+              this.logger = logger;
+            }
+          }
+
+          inject(Logger)(App1, null, 0);
+
+          let container = new Container();
+          let app1 = container.get(App1);
+
+          let logger = app1.logger;
+
+          expect(logger).toEqual(jasmine.any(Logger));
+        });
       });
 
       describe('Optional', ()=> {
@@ -556,6 +625,25 @@ describe('container', () => {
           expect(app.logger).toEqual(jasmine.any(Logger));
         });
 
+        it('injects the instance if its registered in the container using decorator', () => {
+          class Logger {}
+
+          class App {
+            static inject = [Logger];
+            constructor(logger) {
+              this.logger = logger;
+            }
+          }
+
+          optional(Logger)(App, null, 0);
+
+          let container = new Container();
+          container.registerSingleton(Logger, Logger);
+          let app = container.get(App);
+
+          expect(app.logger).toEqual(jasmine.any(Logger));
+        });
+
         it('injects null if key is not registered in the container', () => {
           class VerboseLogger {}
           class Logger {}
@@ -566,6 +654,26 @@ describe('container', () => {
               this.logger = logger;
             }
           }
+
+          let container = new Container();
+          container.registerSingleton(VerboseLogger, Logger);
+          let app = container.get(App);
+
+          expect(app.logger).toBe(null);
+        });
+
+        it('injects null if key is not registered in the container using decorator', () => {
+          class VerboseLogger {}
+          class Logger {}
+
+          class App {
+            static inject = [Logger];
+            constructor(logger) {
+              this.logger = logger;
+            }
+          }
+
+          optional(Logger)(App, null, 0);
 
           let container = new Container();
           container.registerSingleton(VerboseLogger, Logger);
@@ -659,6 +767,32 @@ describe('container', () => {
           expect(app.logger).toBe(parentInstance);
         });
 
+        it('bypasses the current container and injects instance from parent container using decorator', () =>{
+          class Logger {}
+
+          class App {
+            static inject = [Logger];
+            constructor(logger) {
+              this.logger = logger;
+            }
+          }
+
+          parent(App, null, 0);
+
+          let parentContainer = new Container();
+          let parentInstance = new Logger();
+          parentContainer.registerInstance(Logger, parentInstance);
+
+          let childContainer = parentContainer.createChild();
+          let childInstance = new Logger();
+          childContainer.registerInstance(Logger, childInstance);
+          childContainer.registerSingleton(App, App);
+
+          let app = childContainer.get(App);
+
+          expect(app.logger).toBe(parentInstance);
+        });
+
         it('returns null when no parent container exists', () =>{
           class Logger {}
 
@@ -668,6 +802,27 @@ describe('container', () => {
               this.logger = logger;
             }
           }
+
+          let container = new Container();
+          let instance = new Logger();
+          container.registerInstance(Logger, instance);
+
+          let app = container.get(App);
+
+          expect(app.logger).toBe(null);
+        });
+
+        it('returns null when no parent container exists using decorator', () =>{
+          class Logger {}
+
+          class App {
+            static inject = [Logger];
+            constructor(logger) {
+              this.logger = logger;
+            }
+          }
+
+          parent(App, null, 0);
 
           let container = new Container();
           let instance = new Logger();
@@ -703,6 +858,51 @@ describe('container', () => {
             this.service = new GetService(data);
           }
         }
+
+        beforeEach(() => {
+          container = new Container();
+        });
+
+        it('provides a function which, when called, will return the instance', () => {
+          app = container.get(App);
+          service = app.GetService;
+          expect(service()).toEqual(jasmine.any(Service));
+        });
+
+        it('passes data in to the constructor as the second argument', () => {
+          app = container.get(App);
+          expect(app.service.data).toEqual(data);
+        });
+      });
+
+      describe('Factory decorator', () => {
+        let container;
+        let app;
+        let logger;
+        let service;
+        let data = 'test';
+
+        class Logger {}
+
+        class Service {
+          static inject= [Logger];
+          constructor(getLogger, data) {
+            this.getLogger = getLogger;
+            this.data = data;
+          }
+        }
+
+        factory(Logger)(Service, null, 0);
+
+        class App {
+          static inject = [Service];
+          constructor(GetService) {
+            this.GetService = GetService;
+            this.service = new GetService(data);
+          }
+        }
+
+        factory(Service)(App, null, 0);
 
         beforeEach(() => {
           container = new Container();


### PR DESCRIPTION
These decorators assume that you have your listed dependencies available by either `inject` or through metadata provided by the compiler (`paramTypes`).

The only thing I had to do to get things to work correctly was if `inject` is a function, throw an error, otherwise the next function invocation will forget the new value.

See #98 for information.

cc @niieani