### PR TITLE
fix parameter decorators (eg @lazy) for use with @autoinject

### DIFF
--- a/src/injection.js
+++ b/src/injection.js
@@ -8,6 +8,15 @@ export function autoinject(potentialTarget?: any): any {
   let deco = function(target) {
     let previousInject = target.inject ? target.inject.slice() : null; //make a copy of target.inject to avoid changing parent inject
     let autoInject: any = metadata.getOwn(metadata.paramTypes, target) || _emptyParameters;
+
+    let resolvers = metadata.get('aurelia:resolver', target);
+    if (resolvers) {
+      for (let i in resolvers) {
+        autoInject[i] = resolvers[i];
+      }
+      metadata.define('aurelia:resolver', undefined, target);
+    }
+
     if (!previousInject) {
       target.inject = autoInject;
     } else {

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -1,4 +1,4 @@
-import {protocol} from 'aurelia-metadata';
+import {protocol, metadata} from 'aurelia-metadata';
 import {Container} from './container';
 
 /**
@@ -327,13 +327,23 @@ export function getDecoratorDependencies(target, name) {
   return dependencies;
 }
 
+export function getResolvers(target, name) {
+  let resolvers = metadata.getOrCreateOwn('aurelia:resolver', Object, target);
+  if (typeof target.inject === 'function') {
+    throw new Error('Decorator ' + name + ' cannot be used with "inject()".  Please use an array instead.');
+  }
+
+  return resolvers;
+}
+
 /**
 * Decorator: Specifies the dependency should be lazy loaded
 */
 export function lazy(keyValue: any) {
   return function(target, key, index) {
-    let params = getDecoratorDependencies(target, 'lazy');
-    params[index] = Lazy.of(keyValue);
+    let resolvers = getResolvers(target, 'lazy');
+
+    resolvers[index] = Lazy.of(keyValue);
   };
 }
 
@@ -342,8 +352,9 @@ export function lazy(keyValue: any) {
 */
 export function all(keyValue: any) {
   return function(target, key, index) {
-    let params = getDecoratorDependencies(target, 'all');
-    params[index] = All.of(keyValue);
+    let resolvers = getResolvers(target, 'all');
+
+    resolvers[index] = All.of(keyValue);
   };
 }
 
@@ -353,8 +364,10 @@ export function all(keyValue: any) {
 export function optional(checkParentOrTarget: boolean = true) {
   let deco = function(checkParent: boolean) {
     return function(target, key, index) {
-      let params = getDecoratorDependencies(target, 'optional');
-      params[index] = Optional.of(params[index], checkParent);
+      let resolvers = getResolvers(target, 'optional');
+      let params = metadata.getOwn(metadata.paramTypes, target).slice();
+
+      resolvers[index] = Optional.of(params[index], checkParent);
     };
   };
   if (typeof checkParentOrTarget === 'boolean') {
@@ -367,8 +380,10 @@ export function optional(checkParentOrTarget: boolean = true) {
 * Decorator: Specifies the dependency to look at the parent container for resolution
 */
 export function parent(target, key, index) {
-  let params = getDecoratorDependencies(target, 'parent');
-  params[index] = Parent.of(params[index]);
+  let resolvers = getResolvers(target, 'parent');
+  let params = metadata.getOwn(metadata.paramTypes, target).slice();
+
+  resolvers[index] = Parent.of(params[index]);
 }
 
 /**
@@ -376,9 +391,10 @@ export function parent(target, key, index) {
 */
 export function factory(keyValue: any, asValue?: any) {
   return function(target, key, index) {
-    let params = getDecoratorDependencies(target, 'factory');
+    let resolvers = getResolvers(target, 'factory');
     let factory = Factory.of(keyValue);
-    params[index] = asValue ? factory.as(asValue) : factory;
+
+    resolvers[index] = asValue ? factory.as(asValue) : factory;
   };
 }
 
@@ -388,10 +404,12 @@ export function factory(keyValue: any, asValue?: any) {
 export function newInstance(asKeyOrTarget?: any, ...dynamicDependencies: any[]) {
   let deco = function(asKey?: any) {
     return function(target, key, index) {
-      let params = getDecoratorDependencies(target, 'newInstance');
-      params[index] = NewInstance.of(params[index], ...dynamicDependencies);
+      let resolvers = getResolvers(target, 'newInstance');
+      let params = metadata.getOwn(metadata.paramTypes, target).slice();
+
+      resolvers[index] = NewInstance.of(params[index], ...dynamicDependencies);
       if (!!asKey) {
-        params[index].as(asKey);
+        resolvers[index].as(asKey);
       }
     };
   };

--- a/test/container.spec.js
+++ b/test/container.spec.js
@@ -587,20 +587,19 @@ describe('container', () => {
         it('provides a function which, when called, will return the instance using decorator', () => {
           class Logger {}
 
-          class App1 {
-            static inject = [Logger];
-            constructor(getLogger) {
+          class App {
+            constructor(getLogger: () => Logger) {
               this.getLogger = getLogger;
             }
           }
-
-          lazy(Logger)(App1, null, 0);
+          decorators( Reflect.metadata('design:paramtypes', [()=>Logger]) ).on(App);
+          lazy(Logger)(App, null, 0);
+          decorators( autoinject() ).on(App);
 
           let container = new Container();
-          let app1 = container.get(App1);
+          let app = container.get(App);
 
-          let logger = app1.getLogger;
-
+          let logger = app.getLogger;
           expect(logger()).toEqual(jasmine.any(Logger));
         });
       });
@@ -639,13 +638,13 @@ describe('container', () => {
           class Logger extends LoggerBase {}
 
           class App {
-            static inject = [LoggerBase];
             constructor(loggers) {
               this.loggers = loggers;
             }
           }
-
+          decorators( Reflect.metadata('design:paramtypes', [LoggerBase]) ).on(App);
           all(LoggerBase)(App, null, 0);
+          decorators( autoinject() ).on(App);
 
           let container = new Container();
           container.registerSingleton(LoggerBase, VerboseLogger);
@@ -703,13 +702,13 @@ describe('container', () => {
           class Logger {}
 
           class App {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
-
-          optional(Logger)(App, null, 0);
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App);
+          optional()(App, null, 0);
+          decorators( autoinject() ).on(App);
 
           let container = new Container();
           container.registerSingleton(Logger, Logger);
@@ -741,13 +740,13 @@ describe('container', () => {
           class Logger {}
 
           class App {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
-
-          optional(Logger)(App, null, 0);
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App);
+          optional()(App, null, 0);
+          decorators( autoinject() ).on(App);
 
           let container = new Container();
           container.registerSingleton(VerboseLogger, Logger);
@@ -845,13 +844,13 @@ describe('container', () => {
           class Logger {}
 
           class App {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
-
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App);
           parent(App, null, 0);
+          decorators( autoinject() ).on(App);
 
           let parentContainer = new Container();
           let parentInstance = new Logger();
@@ -890,13 +889,13 @@ describe('container', () => {
           class Logger {}
 
           class App {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
-
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App);
           parent(App, null, 0);
+          decorators( autoinject() ).on(App);
 
           let container = new Container();
           let instance = new Logger();
@@ -959,24 +958,24 @@ describe('container', () => {
         class Logger {}
 
         class Service {
-          static inject= [Logger];
           constructor(getLogger, data) {
             this.getLogger = getLogger;
             this.data = data;
           }
         }
-
+        decorators( Reflect.metadata('design:paramtypes', [() => Logger]) ).on(Service);
         factory(Logger)(Service, null, 0);
+        decorators( autoinject() ).on(Service);
 
         class App {
-          static inject = [Service];
           constructor(GetService) {
             this.GetService = GetService;
             this.service = new GetService(data);
           }
         }
-
+        decorators( Reflect.metadata('design:paramtypes', [() => Service]) ).on(App);
         factory(Service)(App, null, 0);
+        decorators( autoinject() ).on(App);
 
         beforeEach(() => {
           container = new Container();
@@ -1021,13 +1020,13 @@ describe('container', () => {
 
         it('decorate to inject a new instance of a dependency', () => {
           class App1 {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
-
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App1);
           newInstance(Logger)(App1, null, 0);
+          decorators( autoinject() ).on(App1);
 
           let container = new Container();
           let logger = container.get(Logger);
@@ -1056,13 +1055,14 @@ describe('container', () => {
 
         it('decorate to inject a new instance of a dependency, with instance dynamic dependency', () => {
           class App1 {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
 
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App1);
           newInstance(Logger, Dependency)(App1, null, 0);
+          decorators( autoinject() ).on(App1);
 
           let container = new Container();
           let logger = container.get(Logger);
@@ -1092,13 +1092,14 @@ describe('container', () => {
 
         it('decorate to inject a new instance of a dependency, with resolver dynamic dependency', () => {
           class App1 {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
 
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App1);
           newInstance(Logger, Lazy.of(Dependency))(App1, null, 0);
+          decorators( autoinject() ).on(App1);
 
           let container = new Container();
           let logger = container.get(Logger);
@@ -1109,6 +1110,175 @@ describe('container', () => {
           expect(app1.logger.dep()).toEqual(jasmine.any(Dependency));
         });
       });
+    });
+  });
+
+  describe('autoinject with custom resolvers', () => {
+    class Dependency {}
+    class LoggerBase {
+      constructor(dep?) {
+        this.dep = dep;
+      }
+    }
+    class VerboseLogger extends LoggerBase {}
+    class Logger extends LoggerBase {}
+    class Service {}
+    class SubService1 {}
+    class SubService2 {}
+
+    it('loads dependencies in tree classes', function() {
+      class ParentApp {
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+      decorators(Reflect.metadata('design:paramtypes', [()=>Logger])).on(ParentApp);
+      lazy(Logger)(ParentApp, null, 0);
+      decorators( autoinject() ).on(ParentApp);   
+
+      class ChildApp extends ParentApp {
+        constructor(service, ...rest) {
+          super(...rest);
+          this.service = service;
+        }
+      }
+      decorators(Reflect.metadata('design:paramtypes', [Service, ()=>Logger])).on(ChildApp);
+      lazy(Logger)(ChildApp, null, 1);
+      decorators( autoinject() ).on(ChildApp);
+
+      class SubChildApp1 extends ChildApp {
+        constructor(subService1, ...rest) {
+          super(...rest);
+          this.subService1 = subService1;
+        }
+      }
+      decorators(Reflect.metadata('design:paramtypes', [()=>SubService1, Service, ()=>Logger])).on(SubChildApp1);
+      lazy(SubService1)(SubChildApp1, null, 0);
+      lazy(Logger)(SubChildApp1, null, 2);
+      decorators( autoinject() ).on(SubChildApp1);
+
+      class SubChildApp2 extends ChildApp {
+        constructor(subService2, ...rest) {
+          super(...rest);
+          this.subService2 = subService2;
+        }
+      }
+      decorators(Reflect.metadata('design:paramtypes', [()=>SubService2, Service, ()=>Logger])).on(SubChildApp2);
+      lazy(SubService2)(SubChildApp2, null, 0);
+      newInstance(Service)(SubChildApp2, null, 2);
+      lazy(Logger)(SubChildApp2, null, 2);
+      decorators( autoinject() ).on(SubChildApp2);
+
+      class SubChildApp3 extends ChildApp {
+      }
+
+      class SubChildApp4 extends ChildApp {
+        constructor(logger, subService1, service) {
+          super(service, logger);
+          this.subService1 = subService1;
+        }
+      }
+      decorators(Reflect.metadata('design:paramtypes', [()=>Logger, ()=>SubService1, Service])).on(SubChildApp4);
+      lazy(SubService1)(SubChildApp4, null, 1);
+      lazy(Logger)(SubChildApp4, null, 0);
+      decorators( autoinject() ).on(SubChildApp4);
+
+      let container = new Container();
+
+      let p_app = container.get(ParentApp);
+      expect(p_app.logger()).toEqual(jasmine.any(Logger));
+
+      let c_app = container.get(ChildApp);
+      expect(c_app.service).toEqual(jasmine.any(Service));
+      expect(c_app.logger()).toEqual(jasmine.any(Logger));
+
+      let app1 = container.get(SubChildApp1);
+      expect(app1.subService1()).toEqual(jasmine.any(SubService1));
+      expect(app1.service).toEqual(jasmine.any(Service));
+      expect(app1.logger()).toEqual(jasmine.any(Logger));
+
+      let app2 = container.get(SubChildApp2);
+      expect(app2.subService2()).toEqual(jasmine.any(SubService2));
+      expect(app2.service).toEqual(jasmine.any(Service));
+      expect(app2.logger()).toEqual(jasmine.any(Logger));
+
+      let app3 = container.get(SubChildApp3);
+      expect(app3.service).toEqual(jasmine.any(Service));
+      expect(app3.logger()).toEqual(jasmine.any(Logger));
+
+      let app4 = container.get(SubChildApp4);
+      expect(app4.subService1()).toEqual(jasmine.any(SubService1));
+      expect(app4.service).toEqual(jasmine.any(Service));
+      expect(app4.logger()).toEqual(jasmine.any(Logger));
+    });
+
+    it('allows multiple parameter decorators', () => {    
+      let data = 'test';
+
+      class MyService {
+        constructor(getLogger, data) {
+          this.getLogger = getLogger;
+          this.data = data;
+        }
+      }
+      decorators( Reflect.metadata('design:paramtypes', [() => Logger]) ).on(MyService);
+      factory(Logger)(MyService, null, 0);
+      decorators( autoinject() ).on(MyService);
+
+      class App {
+        constructor(getLogger: () => Logger, loggers, optionalLogger, parentLogger, newLogger, GetService) {
+          this.getLogger = getLogger;
+          this.loggers = loggers;
+          this.optionalLogger = optionalLogger;
+          this.parentLogger = parentLogger;
+          this.newLogger = newLogger;
+          this.GetService = GetService;
+          this.service = new GetService(data);
+        }
+      }
+
+      decorators( Reflect.metadata('design:paramtypes', [()=>Logger, LoggerBase, Logger, Logger, Logger, MyService]) ).on(App);
+      lazy(Logger)(App, null, 0);
+      all(LoggerBase)(App, null, 1);
+      optional()(App, null, 2);
+      parent(App, null, 3);
+      newInstance(Logger, Dependency)(App, null, 4);
+      factory(MyService)(App, null, 5);
+      decorators( autoinject() ).on(App);
+
+      let parentContainer = new Container();
+      let parentInstance = new Logger();
+      parentContainer.registerInstance(Logger, parentInstance);
+
+      let container = parentContainer.createChild();
+      let childInstance = new Logger();
+      container.registerSingleton(LoggerBase, VerboseLogger);
+      container.registerTransient(LoggerBase, Logger);
+      container.registerSingleton(Logger, Logger);
+      container.registerInstance(Logger, childInstance);
+      container.registerSingleton(App, App);
+
+      let app = container.get(App);
+
+      let logger = app.getLogger;
+      expect(logger()).toEqual(jasmine.any(Logger));
+
+      expect(app.loggers).toEqual(jasmine.any(Array));
+      expect(app.loggers.length).toBe(2);
+      expect(app.loggers[0]).toEqual(jasmine.any(VerboseLogger));
+      expect(app.loggers[1]).toEqual(jasmine.any(Logger));
+
+      expect(app.optionalLogger).toEqual(jasmine.any(Logger));
+
+      expect(app.parentLogger).toBe(parentInstance);
+
+      expect(app.newLogger).toEqual(jasmine.any(Logger));
+      expect(app.newLogger).not.toBe(logger);
+      expect(app.newLogger.dep).toEqual(jasmine.any(Dependency));
+
+      let service = app.GetService;
+      expect(service()).toEqual(jasmine.any(MyService));
+      expect(app.service.data).toEqual(data);
     });
   });
 });


### PR DESCRIPTION
The original implentation of the parameter resolvers (eg @lazy), changed the static inject property accordingly.  This approach failed to take into account that the inject property had had been inherited from a parent class. When @autoinject was fixed to take inheritence into account as such, the parameter decorator implentation broke for simple classes as well. This wasn't noticed since the tests for the parameters only tested them individually, not taken into account that they only work together with autoinject and that a change of autoinject might break they usage.

Basically, the original version relied on matching indizes for static inject and the constructor parameters. That fails with inheritence, when static inject might have been inherited and having nothing to do with the constructor parameters of the derived class.

The fix of autoinject for inheritence as such, used compared of static inject and the constructor parameters to find the right position to update static inject. This approach fails with parameter decorators, since types used in static inject and the constructor parameters don't match (eg Lazy.of(MyClass) in inject vs ()=>MyClass of the constructor parameters).

This solution proposed here is to store the resolvers temporarily and later, in @autoinject, use them to adjust the copied types from the constructor parameters first before merging them with potential previous inject from parent classes.

The tests for the parameter decorators have been adjusted to use @autoinject, so that the previous bug would have been picked up.
Additionally, test have been added for usage of parameter decorators and inheritance and the use of multiple parameter decorators to ensure none interferes with the other.

fixes ##153
propably also #155 