### PR TITLE
Removing unusable option of the factory decorator

### DIFF
--- a/doc/article/en-US/dependency-injection-basics.md
+++ b/doc/article/en-US/dependency-injection-basics.md
@@ -331,7 +331,7 @@ If using TypeScript, keep in mind that `@autoinject` won't allow you to use `Res
 * `all(key)`
 * `optional(checkParent?)`
 * `parent`
-* `factory(key, asValue?)`
+* `factory(key)`
 * `newInstance(asKey?, dynamicDependencies: [any])`
 
 Here's an example of how we might express a dependency on `HttpClient` that we may or may not actually need to use, depending on runtime scenarios:

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -392,11 +392,10 @@ export function parent(target, key, index) {
 /**
 * Decorator: Specifies the dependency to create a factory method, that can accept optional arguments
 */
-export function factory(keyValue: any, asValue?: any) {
+export function factory(keyValue: any) {
   return function(target, key, index) {
     let inject = getDecoratorDependencies(target);
-    let factory = Factory.of(keyValue);
-    inject[index] = asValue ? factory.as(asValue) : factory;
+    inject[index] = Factory.of(keyValue);
   };
 }
 

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -400,7 +400,8 @@ export function factory(keyValue: any) {
 }
 
 /**
-* Decorator: Specifies the dependency as a new instance
+* Decorator: Specifies the dependency as a new instance. Instances can optionally be registered in the container
+* under a different key and/or use dynamic dependencies
 */
 export function newInstance(asKeyOrTarget?: any, ...dynamicDependencies: any[]) {
   let deco = function(asKey?: any) {


### PR DESCRIPTION
I have no idea what the asValue option of the factory decorator was supposed to do, but using it certainly just throws an error as the Factory resolver has no method `as(key)`. So, i suggest to just remove that option.

+added a small clarification for the newInstance decorator

Note: The decorators don't work atm, but that issue is independent of that.