### PR TITLE
Fixing parameter decorators

### DIFF
--- a/doc/article/en-US/dependency-injection-basics.md
+++ b/doc/article/en-US/dependency-injection-basics.md
@@ -325,14 +325,14 @@ As mentioned above, the DI container uses `Resolvers` internally to provide all 
 * `NewInstance` - Used to inject a new instance of a dependency, without regard for existing instances in the container.
   * ex. `NewInstance.of(CustomClass).as(Another)`
 
-If using TypeScript, keep in mind that `@autoinject` won't allow you to use `Resolvers`. Instead, you may use argument decorators, without duplicating argument order, which you otherwise have to maintain when using the class decorator or the static `inject` property. Available function parameter decorators are:
+If using TypeScript, keep in mind that `@autoinject` won't allow you to use `Resolvers`. Instead, you may use argument decorators, without duplicating argument order, which you otherwise have to maintain when using the class decorator or the static `inject` property. You also can use `inject` as argument decorator for your own custom resolvers, eg `constructor(@inject(NewInstance.of(HttpClient)) public client: HttpClient){...}`. Available build-in function parameter decorators are:
 
 * `lazy(key)`
 * `all(key)`
 * `optional(checkParent?)`
 * `parent`
 * `factory(key, asValue?)`
-* `newInstance(key?)`
+* `newInstance(asKey?, dynamicDependencies: [any])`
 
 Here's an example of how we might express a dependency on `HttpClient` that we may or may not actually need to use, depending on runtime scenarios:
 

--- a/src/injection.js
+++ b/src/injection.js
@@ -6,24 +6,16 @@ import {_emptyParameters} from './container';
 */
 export function autoinject(potentialTarget?: any): any {
   let deco = function(target) {
-    let previousInject = target.inject ? target.inject.slice() : null; //make a copy of target.inject to avoid changing parent inject
+    let previousInject = target.hasOwnProperty('inject') ? target.inject : null;
     let autoInject: any = metadata.getOwn(metadata.paramTypes, target) || _emptyParameters;
     if (!previousInject) {
       target.inject = autoInject;
     } else {
-      for (let i = 0; i < autoInject.length; i++) {
-        //check if previously injected.
-        if (previousInject[i] && previousInject[i] !== autoInject[i]) {
-          const prevIndex = previousInject.indexOf(autoInject[i]);
-          if (prevIndex > -1) {
-            previousInject.splice(prevIndex, 1);
-          }
-          previousInject.splice((prevIndex > -1 && prevIndex < i) ? i - 1 : i, 0, autoInject[i]);
-        } else if (!previousInject[i]) {//else add
+      for (let i = 0; i++; i < autoInject.length) {
+        if (!previousInject[i]) {
           previousInject[i] = autoInject[i];
         }
       }
-      target.inject = previousInject;
     }
   };
 

--- a/src/injection.js
+++ b/src/injection.js
@@ -15,21 +15,16 @@ export function autoinject(potentialTarget?: any): any {
 }
 
 /**
-* Decorator: Specifies the dependencies that should be injected by the DI Container into the decoratored class/function.
+* Decorator: Specifies the dependencies that should be injected by the DI Container into the decorated class/function.
 */
 export function inject(...rest: any[]): any {
   return function(target, key, descriptor) {
-    // handle when used as a parameter
-    if (typeof descriptor === 'number' && rest.length === 1) {
-      let params = target.inject;
-      if (typeof params === 'function') {
-        throw new Error('Decorator inject cannot be used with "inject()".  Please use an array instead.');
+    // handle when used as a parameter decorator
+    if (typeof descriptor === 'number') {
+      autoinject(target);
+      if (rest.length === 1) {
+        target.inject[descriptor] = rest[0];
       }
-      if (!params) {
-        params = metadata.getOwn(metadata.paramTypes, target).slice();
-        target.inject = params;
-      }
-      params[descriptor] = rest[0];
       return;
     }
     // if it's true then we injecting rest into function and not Class constructor

--- a/src/injection.js
+++ b/src/injection.js
@@ -6,16 +6,8 @@ import {_emptyParameters} from './container';
 */
 export function autoinject(potentialTarget?: any): any {
   let deco = function(target) {
-    let previousInject = target.hasOwnProperty('inject') ? target.inject : null;
-    let autoInject: any = metadata.getOwn(metadata.paramTypes, target) || _emptyParameters;
-    if (!previousInject) {
-      target.inject = autoInject;
-    } else {
-      for (let i = 0; i++; i < autoInject.length) {
-        if (!previousInject[i]) {
-          previousInject[i] = autoInject[i];
-        }
-      }
+    if (!target.hasOwnProperty('inject')) {
+      target.inject = (metadata.getOwn(metadata.paramTypes, target) || _emptyParameters).slice();
     }
   };
 

--- a/src/injection.js
+++ b/src/injection.js
@@ -7,7 +7,14 @@ import {_emptyParameters} from './container';
 export function autoinject(potentialTarget?: any): any {
   let deco = function(target) {
     if (!target.hasOwnProperty('inject')) {
-      target.inject = (metadata.getOwn(metadata.paramTypes, target) || _emptyParameters).slice();
+      target.inject = (metadata.getOwn(metadata.paramTypes, target) || Object.freeze(new Array(metadata.paramTypes.length))).slice();
+      metadata.define('aurelia:inject', true, target);
+
+      return;
+    }
+
+    if (!metadata.get('aurelia:inject', target)) {
+      throw new Error('Decorator autoinject cannot be used with "static inject"');
     }
   };
 

--- a/src/injection.js
+++ b/src/injection.js
@@ -19,7 +19,7 @@ export function autoinject(potentialTarget?: any): any {
 */
 export function inject(...rest: any[]): any {
   return function(target, key, descriptor) {
-    // handle when used as a parameter decorator
+    // handle when used as a constructor parameter decorator
     if (typeof descriptor === 'number') {
       autoinject(target);
       if (rest.length === 1) {

--- a/src/injection.js
+++ b/src/injection.js
@@ -7,14 +7,7 @@ import {_emptyParameters} from './container';
 export function autoinject(potentialTarget?: any): any {
   let deco = function(target) {
     if (!target.hasOwnProperty('inject')) {
-      target.inject = (metadata.getOwn(metadata.paramTypes, target) || Object.freeze(new Array(metadata.paramTypes.length))).slice();
-      metadata.define('aurelia:inject', true, target);
-
-      return;
-    }
-
-    if (!metadata.get('aurelia:inject', target)) {
-      throw new Error('Decorator autoinject cannot be used with "static inject"');
+      target.inject = (metadata.getOwn(metadata.paramTypes, target) || _emptyParameters).slice();
     }
   };
 

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -1,4 +1,4 @@
-import {protocol} from 'aurelia-metadata';
+import {protocol, metadata} from 'aurelia-metadata';
 import {Container} from './container';
 
 /**
@@ -315,6 +315,9 @@ export class NewInstance {
 }
 
 export function getDecoratorDependencies(target, name) {
+  if (!target.hasOwnProperty('inject')) {
+    Object.defineProperty(target, 'inject', {value: undefined, writable: true});
+  }
   let dependencies = target.inject;
   if (typeof dependencies === 'function') {
     throw new Error('Decorator ' + name + ' cannot be used with "inject()".  Please use an array instead.');

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -317,13 +317,7 @@ export class NewInstance {
 export function getDecoratorDependencies(target, name) {
   if (!target.hasOwnProperty('inject')) {
     target.inject = (metadata.getOwn(metadata.paramTypes, target) || _emptyParameters).slice();
-    metadata.define('aurelia:inject', true, target);
   }
-
-  if (!metadata.get('aurelia:inject', target)) {
-    throw new Error(`Decorator ${name} cannot be used with "static inject"`);
-  }
-
   return target.inject;
 }
 

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -27,6 +27,53 @@ export interface Resolver {
 }
 
 /**
+* Used to resolve instances, singletons, transients, aliases
+*/
+@resolver()
+export class StrategyResolver {
+  strategy: StrategyResolver | number;
+  state: any;
+
+  /**
+  * Creates an instance of the StrategyResolver class.
+  * @param strategy The type of resolution strategy.
+  * @param state The state associated with the resolution strategy.
+  */
+  constructor(strategy, state) {
+    this.strategy = strategy;
+    this.state = state;
+  }
+
+  /**
+  * Called by the container to allow custom resolution of dependencies for a function/class.
+  * @param container The container to resolve from.
+  * @param key The key that the resolver was registered as.
+  * @return Returns the resolved object.
+  */
+  get(container: Container, key: any): any {
+    switch (this.strategy) {
+    case 0: //instance
+      return this.state;
+    case 1: //singleton
+      let singleton = container.invoke(this.state);
+      this.state = singleton;
+      this.strategy = 0;
+      return singleton;
+    case 2: //transient
+      return container.invoke(this.state);
+    case 3: //function
+      return this.state(container, key, this);
+    case 4: //array
+      return this.state[0].get(container, key);
+    case 5: //alias
+      return container.get(this.state);
+    default:
+      throw new Error('Invalid strategy: ' + this.strategy);
+    }
+  }
+}
+
+/**
 * Used to allow functions/classes to specify lazy resolution logic.
 */
 @resolver()
@@ -141,7 +188,6 @@ export class Optional {
   }
 }
 
-
 /**
 * Used to inject the dependency from the parent container instead of the current one.
 */
@@ -176,50 +222,6 @@ export class Parent {
   */
   static of(key: any) : Parent {
     return new Parent(key);
-  }
-}
-
-@resolver()
-export class StrategyResolver {
-  strategy: StrategyResolver | number;
-  state: any;
-
-  /**
-  * Creates an instance of the StrategyResolver class.
-  * @param strategy The type of resolution strategy.
-  * @param state The state associated with the resolution strategy.
-  */
-  constructor(strategy, state) {
-    this.strategy = strategy;
-    this.state = state;
-  }
-
-  /**
-  * Called by the container to allow custom resolution of dependencies for a function/class.
-  * @param container The container to resolve from.
-  * @param key The key that the resolver was registered as.
-  * @return Returns the resolved object.
-  */
-  get(container: Container, key: any): any {
-    switch (this.strategy) {
-    case 0: //instance
-      return this.state;
-    case 1: //singleton
-      let singleton = container.invoke(this.state);
-      this.state = singleton;
-      this.strategy = 0;
-      return singleton;
-    case 2: //transient
-      return container.invoke(this.state);
-    case 3: //function
-      return this.state(container, key, this);
-    case 4: //array
-      return this.state[0].get(container, key);
-    case 5: //alias
-      return container.get(this.state);
-    default:
-      throw new Error('Invalid strategy: ' + this.strategy);
-    }
   }
 }
 

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -317,7 +317,13 @@ export class NewInstance {
 export function getDecoratorDependencies(target, name) {
   if (!target.hasOwnProperty('inject')) {
     target.inject = (metadata.getOwn(metadata.paramTypes, target) || _emptyParameters).slice();
+    metadata.define('aurelia:inject', true, target);
   }
+
+  if (!metadata.get('aurelia:inject', target)) {
+    throw new Error(`Decorator ${name} cannot be used with "static inject"`);
+  }
+
   return target.inject;
 }
 

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -1,5 +1,5 @@
 import {protocol, metadata} from 'aurelia-metadata';
-import {Container} from './container';
+import {Container, _emptyParameters} from './container';
 
 /**
 * Decorator: Indicates that the decorated class/object is a custom resolver.
@@ -316,18 +316,9 @@ export class NewInstance {
 
 export function getDecoratorDependencies(target, name) {
   if (!target.hasOwnProperty('inject')) {
-    Object.defineProperty(target, 'inject', {value: undefined, writable: true});
+    target.inject = (metadata.getOwn(metadata.paramTypes, target) || _emptyParameters).slice();
   }
-  let dependencies = target.inject;
-  if (typeof dependencies === 'function') {
-    throw new Error('Decorator ' + name + ' cannot be used with "inject()".  Please use an array instead.');
-  }
-  if (!dependencies) {
-    dependencies = metadata.getOwn(metadata.paramTypes, target).slice();
-    target.inject = dependencies;
-  }
-
-  return dependencies;
+  return target.inject;
 }
 
 /**
@@ -335,8 +326,8 @@ export function getDecoratorDependencies(target, name) {
 */
 export function lazy(keyValue: any) {
   return function(target, key, index) {
-    let params = getDecoratorDependencies(target, 'lazy');
-    params[index] = Lazy.of(keyValue);
+    let inject = getDecoratorDependencies(target, 'lazy');
+    inject[index] = Lazy.of(keyValue);
   };
 }
 
@@ -345,8 +336,8 @@ export function lazy(keyValue: any) {
 */
 export function all(keyValue: any) {
   return function(target, key, index) {
-    let params = getDecoratorDependencies(target, 'all');
-    params[index] = All.of(keyValue);
+    let inject = getDecoratorDependencies(target, 'all');
+    inject[index] = All.of(keyValue);
   };
 }
 
@@ -356,8 +347,8 @@ export function all(keyValue: any) {
 export function optional(checkParentOrTarget: boolean = true) {
   let deco = function(checkParent: boolean) {
     return function(target, key, index) {
-      let params = getDecoratorDependencies(target, 'optional');
-      params[index] = Optional.of(params[index], checkParent);
+      let inject = getDecoratorDependencies(target, 'optional');
+      inject[index] = Optional.of(inject[index], checkParent);
     };
   };
   if (typeof checkParentOrTarget === 'boolean') {
@@ -370,8 +361,8 @@ export function optional(checkParentOrTarget: boolean = true) {
 * Decorator: Specifies the dependency to look at the parent container for resolution
 */
 export function parent(target, key, index) {
-  let params = getDecoratorDependencies(target, 'parent');
-  params[index] = Parent.of(params[index]);
+  let inject = getDecoratorDependencies(target, 'parent');
+  inject[index] = Parent.of(inject[index]);
 }
 
 /**
@@ -379,9 +370,9 @@ export function parent(target, key, index) {
 */
 export function factory(keyValue: any, asValue?: any) {
   return function(target, key, index) {
-    let params = getDecoratorDependencies(target, 'factory');
+    let inject = getDecoratorDependencies(target, 'factory');
     let factory = Factory.of(keyValue);
-    params[index] = asValue ? factory.as(asValue) : factory;
+    inject[index] = asValue ? factory.as(asValue) : factory;
   };
 }
 
@@ -391,10 +382,10 @@ export function factory(keyValue: any, asValue?: any) {
 export function newInstance(asKeyOrTarget?: any, ...dynamicDependencies: any[]) {
   let deco = function(asKey?: any) {
     return function(target, key, index) {
-      let params = getDecoratorDependencies(target, 'newInstance');
-      params[index] = NewInstance.of(params[index], ...dynamicDependencies);
+      let inject = getDecoratorDependencies(target, 'newInstance');
+      inject[index] = NewInstance.of(inject[index], ...dynamicDependencies);
       if (!!asKey) {
-        params[index].as(asKey);
+        inject[index].as(asKey);
       }
     };
   };

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -1,5 +1,6 @@
-import {protocol, metadata} from 'aurelia-metadata';
-import {Container, _emptyParameters} from './container';
+import {protocol} from 'aurelia-metadata';
+import {Container} from './container';
+import {autoinject} from './injection';
 
 /**
 * Decorator: Indicates that the decorated class/object is a custom resolver.
@@ -315,9 +316,8 @@ export class NewInstance {
 }
 
 export function getDecoratorDependencies(target, name) {
-  if (!target.hasOwnProperty('inject')) {
-    target.inject = (metadata.getOwn(metadata.paramTypes, target) || _emptyParameters).slice();
-  }
+  autoinject(target);
+
   return target.inject;
 }
 

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -265,8 +265,12 @@ export class Factory {
 */
 @resolver()
 export class NewInstance {
-  key;
-  asKey;
+  /** @internal */
+  key: any;
+  /** @internal */
+  asKey: any;
+  /** @internal */
+  dynamicDependencies: any[];
 
   /**
   * Creates an instance of the NewInstance class.
@@ -315,7 +319,12 @@ export class NewInstance {
   }
 }
 
-export function getDecoratorDependencies(target, name) {
+/**
+* Used by parameter decorators to call autoinject for the target and retrieve the target's inject property.
+* @param target The target class.
+* @return Returns the target's own inject property.
+*/
+export function getDecoratorDependencies(target) {
   autoinject(target);
 
   return target.inject;
@@ -326,7 +335,7 @@ export function getDecoratorDependencies(target, name) {
 */
 export function lazy(keyValue: any) {
   return function(target, key, index) {
-    let inject = getDecoratorDependencies(target, 'lazy');
+    let inject = getDecoratorDependencies(target);
     inject[index] = Lazy.of(keyValue);
   };
 }
@@ -336,7 +345,7 @@ export function lazy(keyValue: any) {
 */
 export function all(keyValue: any) {
   return function(target, key, index) {
-    let inject = getDecoratorDependencies(target, 'all');
+    let inject = getDecoratorDependencies(target);
     inject[index] = All.of(keyValue);
   };
 }
@@ -347,7 +356,7 @@ export function all(keyValue: any) {
 export function optional(checkParentOrTarget: boolean = true) {
   let deco = function(checkParent: boolean) {
     return function(target, key, index) {
-      let inject = getDecoratorDependencies(target, 'optional');
+      let inject = getDecoratorDependencies(target);
       inject[index] = Optional.of(inject[index], checkParent);
     };
   };
@@ -361,7 +370,7 @@ export function optional(checkParentOrTarget: boolean = true) {
 * Decorator: Specifies the dependency to look at the parent container for resolution
 */
 export function parent(target, key, index) {
-  let inject = getDecoratorDependencies(target, 'parent');
+  let inject = getDecoratorDependencies(target);
   inject[index] = Parent.of(inject[index]);
 }
 
@@ -370,7 +379,7 @@ export function parent(target, key, index) {
 */
 export function factory(keyValue: any, asValue?: any) {
   return function(target, key, index) {
-    let inject = getDecoratorDependencies(target, 'factory');
+    let inject = getDecoratorDependencies(target);
     let factory = Factory.of(keyValue);
     inject[index] = asValue ? factory.as(asValue) : factory;
   };
@@ -382,7 +391,7 @@ export function factory(keyValue: any, asValue?: any) {
 export function newInstance(asKeyOrTarget?: any, ...dynamicDependencies: any[]) {
   let deco = function(asKey?: any) {
     return function(target, key, index) {
-      let inject = getDecoratorDependencies(target, 'newInstance');
+      let inject = getDecoratorDependencies(target);
       inject[index] = NewInstance.of(inject[index], ...dynamicDependencies);
       if (!!asKey) {
         inject[index].as(asKey);

--- a/test/container.spec.js
+++ b/test/container.spec.js
@@ -271,7 +271,7 @@ describe('container', () => {
         }
         decorators(Reflect.metadata('design:paramtypes', [()=>SubService2, Service, ()=>Logger])).on(SubChildApp2);
         lazy(SubService2)(SubChildApp2, null, 0);
-        newInstance(Service)(SubChildApp2, null, 2);
+        newInstance(Service)(SubChildApp2, null, 1);
         lazy(Logger)(SubChildApp2, null, 2);
         decorators( autoinject() ).on(SubChildApp2);
   
@@ -304,8 +304,10 @@ describe('container', () => {
         expect(app1.logger()).toEqual(jasmine.any(Logger));
   
         let app2 = container.get(SubChildApp2);
+        let service = container.get(Service);
         expect(app2.subService2()).toEqual(jasmine.any(SubService2));
         expect(app2.service).toEqual(jasmine.any(Service));
+        expect(app2.service).not.toBe(service);
         expect(app2.logger()).toEqual(jasmine.any(Logger));
   
         let app3 = container.get(SubChildApp3);

--- a/test/container.spec.js
+++ b/test/container.spec.js
@@ -587,20 +587,19 @@ describe('container', () => {
         it('provides a function which, when called, will return the instance using decorator', () => {
           class Logger {}
 
-          class App1 {
-            static inject = [Logger];
-            constructor(getLogger) {
+          class App {
+            constructor(getLogger: () => Logger) {
               this.getLogger = getLogger;
             }
           }
-
-          lazy(Logger)(App1, null, 0);
+          decorators( Reflect.metadata('design:paramtypes', [()=>Logger]) ).on(App);
+          lazy(Logger)(App, null, 0);
+          decorators( autoinject() ).on(App);
 
           let container = new Container();
-          let app1 = container.get(App1);
+          let app = container.get(App);
 
-          let logger = app1.getLogger;
-
+          let logger = app.getLogger;
           expect(logger()).toEqual(jasmine.any(Logger));
         });
       });
@@ -639,13 +638,13 @@ describe('container', () => {
           class Logger extends LoggerBase {}
 
           class App {
-            static inject = [LoggerBase];
             constructor(loggers) {
               this.loggers = loggers;
             }
           }
-
+          decorators( Reflect.metadata('design:paramtypes', [LoggerBase]) ).on(App);
           all(LoggerBase)(App, null, 0);
+          decorators( autoinject() ).on(App);
 
           let container = new Container();
           container.registerSingleton(LoggerBase, VerboseLogger);
@@ -703,13 +702,13 @@ describe('container', () => {
           class Logger {}
 
           class App {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
-
-          optional(Logger)(App, null, 0);
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App);
+          optional()(App, null, 0);
+          decorators( autoinject() ).on(App);
 
           let container = new Container();
           container.registerSingleton(Logger, Logger);
@@ -741,13 +740,13 @@ describe('container', () => {
           class Logger {}
 
           class App {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
-
-          optional(Logger)(App, null, 0);
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App);
+          optional()(App, null, 0);
+          decorators( autoinject() ).on(App);
 
           let container = new Container();
           container.registerSingleton(VerboseLogger, Logger);
@@ -794,6 +793,29 @@ describe('container', () => {
           expect(app.logger).toBe(null);
         });
 
+        it('doesn\'t check the parent container hierarchy when checkParent is false using decorator', () => {
+          class Logger {}
+
+          class App {
+            constructor(logger) {
+              this.logger = logger;
+            }
+          }
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App);
+          optional(false)(App, null, 0);
+          decorators( autoinject() ).on(App);
+
+          let parentContainer = new Container();
+          parentContainer.registerSingleton(Logger, Logger);
+
+          let childContainer = parentContainer.createChild();
+          childContainer.registerSingleton(App, App);
+
+          let app = childContainer.get(App);
+
+          expect(app.logger).toBe(null);
+        });
+
         it('checks the parent container hierarchy when checkParent is true or default', () => {
           class Logger {}
 
@@ -803,6 +825,29 @@ describe('container', () => {
               this.logger = logger;
             }
           }
+
+          let parentContainer = new Container();
+          parentContainer.registerSingleton(Logger, Logger);
+
+          let childContainer = parentContainer.createChild();
+          childContainer.registerSingleton(App, App);
+
+          let app = childContainer.get(App);
+
+          expect(app.logger).toEqual(jasmine.any(Logger));
+        });
+
+        it('checks the parent container hierarchy when checkParent is true or default using decorator', () => {
+          class Logger {}
+
+          class App {
+            constructor(logger) {
+              this.logger = logger;
+            }
+          }
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App);
+          optional()(App, null, 0);
+          decorators( autoinject() ).on(App);
 
           let parentContainer = new Container();
           parentContainer.registerSingleton(Logger, Logger);
@@ -845,13 +890,13 @@ describe('container', () => {
           class Logger {}
 
           class App {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
-
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App);
           parent(App, null, 0);
+          decorators( autoinject() ).on(App);
 
           let parentContainer = new Container();
           let parentInstance = new Logger();
@@ -890,13 +935,13 @@ describe('container', () => {
           class Logger {}
 
           class App {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
-
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App);
           parent(App, null, 0);
+          decorators( autoinject() ).on(App);
 
           let container = new Container();
           let instance = new Logger();
@@ -959,24 +1004,24 @@ describe('container', () => {
         class Logger {}
 
         class Service {
-          static inject= [Logger];
           constructor(getLogger, data) {
             this.getLogger = getLogger;
             this.data = data;
           }
         }
-
+        decorators( Reflect.metadata('design:paramtypes', [() => Logger]) ).on(Service);
         factory(Logger)(Service, null, 0);
+        decorators( autoinject() ).on(Service);
 
         class App {
-          static inject = [Service];
           constructor(GetService) {
             this.GetService = GetService;
             this.service = new GetService(data);
           }
         }
-
+        decorators( Reflect.metadata('design:paramtypes', [() => Service]) ).on(App);
         factory(Service)(App, null, 0);
+        decorators( autoinject() ).on(App);
 
         beforeEach(() => {
           container = new Container();
@@ -1021,13 +1066,13 @@ describe('container', () => {
 
         it('decorate to inject a new instance of a dependency', () => {
           class App1 {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
-
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App1);
           newInstance(Logger)(App1, null, 0);
+          decorators( autoinject() ).on(App1);
 
           let container = new Container();
           let logger = container.get(Logger);
@@ -1056,13 +1101,14 @@ describe('container', () => {
 
         it('decorate to inject a new instance of a dependency, with instance dynamic dependency', () => {
           class App1 {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
 
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App1);
           newInstance(Logger, Dependency)(App1, null, 0);
+          decorators( autoinject() ).on(App1);
 
           let container = new Container();
           let logger = container.get(Logger);
@@ -1092,13 +1138,14 @@ describe('container', () => {
 
         it('decorate to inject a new instance of a dependency, with resolver dynamic dependency', () => {
           class App1 {
-            static inject = [Logger];
             constructor(logger) {
               this.logger = logger;
             }
           }
 
+          decorators( Reflect.metadata('design:paramtypes', [Logger]) ).on(App1);
           newInstance(Logger, Lazy.of(Dependency))(App1, null, 0);
+          decorators( autoinject() ).on(App1);
 
           let container = new Container();
           let logger = container.get(Logger);
@@ -1109,6 +1156,175 @@ describe('container', () => {
           expect(app1.logger.dep()).toEqual(jasmine.any(Dependency));
         });
       });
+    });
+  });
+
+  describe('autoinject with custom resolvers', () => {
+    class Dependency {}
+    class LoggerBase {
+      constructor(dep?) {
+        this.dep = dep;
+      }
+    }
+    class VerboseLogger extends LoggerBase {}
+    class Logger extends LoggerBase {}
+    class Service {}
+    class SubService1 {}
+    class SubService2 {}
+
+    it('loads dependencies in tree classes', function() {
+      class ParentApp {
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+      decorators(Reflect.metadata('design:paramtypes', [()=>Logger])).on(ParentApp);
+      lazy(Logger)(ParentApp, null, 0);
+      decorators( autoinject() ).on(ParentApp);   
+
+      class ChildApp extends ParentApp {
+        constructor(service, ...rest) {
+          super(...rest);
+          this.service = service;
+        }
+      }
+      decorators(Reflect.metadata('design:paramtypes', [Service, ()=>Logger])).on(ChildApp);
+      lazy(Logger)(ChildApp, null, 1);
+      decorators( autoinject() ).on(ChildApp);
+
+      class SubChildApp1 extends ChildApp {
+        constructor(subService1, ...rest) {
+          super(...rest);
+          this.subService1 = subService1;
+        }
+      }
+      decorators(Reflect.metadata('design:paramtypes', [()=>SubService1, Service, ()=>Logger])).on(SubChildApp1);
+      lazy(SubService1)(SubChildApp1, null, 0);
+      lazy(Logger)(SubChildApp1, null, 2);
+      decorators( autoinject() ).on(SubChildApp1);
+
+      class SubChildApp2 extends ChildApp {
+        constructor(subService2, ...rest) {
+          super(...rest);
+          this.subService2 = subService2;
+        }
+      }
+      decorators(Reflect.metadata('design:paramtypes', [()=>SubService2, Service, ()=>Logger])).on(SubChildApp2);
+      lazy(SubService2)(SubChildApp2, null, 0);
+      newInstance(Service)(SubChildApp2, null, 2);
+      lazy(Logger)(SubChildApp2, null, 2);
+      decorators( autoinject() ).on(SubChildApp2);
+
+      class SubChildApp3 extends ChildApp {
+      }
+
+      class SubChildApp4 extends ChildApp {
+        constructor(logger, subService1, service) {
+          super(service, logger);
+          this.subService1 = subService1;
+        }
+      }
+      decorators(Reflect.metadata('design:paramtypes', [()=>Logger, ()=>SubService1, Service])).on(SubChildApp4);
+      lazy(SubService1)(SubChildApp4, null, 1);
+      lazy(Logger)(SubChildApp4, null, 0);
+      decorators( autoinject() ).on(SubChildApp4);
+
+      let container = new Container();
+
+      let p_app = container.get(ParentApp);
+      expect(p_app.logger()).toEqual(jasmine.any(Logger));
+
+      let c_app = container.get(ChildApp);
+      expect(c_app.service).toEqual(jasmine.any(Service));
+      expect(c_app.logger()).toEqual(jasmine.any(Logger));
+
+      let app1 = container.get(SubChildApp1);
+      expect(app1.subService1()).toEqual(jasmine.any(SubService1));
+      expect(app1.service).toEqual(jasmine.any(Service));
+      expect(app1.logger()).toEqual(jasmine.any(Logger));
+
+      let app2 = container.get(SubChildApp2);
+      expect(app2.subService2()).toEqual(jasmine.any(SubService2));
+      expect(app2.service).toEqual(jasmine.any(Service));
+      expect(app2.logger()).toEqual(jasmine.any(Logger));
+
+      let app3 = container.get(SubChildApp3);
+      expect(app3.service).toEqual(jasmine.any(Service));
+      expect(app3.logger()).toEqual(jasmine.any(Logger));
+
+      let app4 = container.get(SubChildApp4);
+      expect(app4.subService1()).toEqual(jasmine.any(SubService1));
+      expect(app4.service).toEqual(jasmine.any(Service));
+      expect(app4.logger()).toEqual(jasmine.any(Logger));
+    });
+
+    it('allows multiple parameter decorators', () => {    
+      let data = 'test';
+
+      class MyService {
+        constructor(getLogger, data) {
+          this.getLogger = getLogger;
+          this.data = data;
+        }
+      }
+      decorators( Reflect.metadata('design:paramtypes', [() => Logger]) ).on(MyService);
+      factory(Logger)(MyService, null, 0);
+      decorators( autoinject() ).on(MyService);
+
+      class App {
+        constructor(getLogger: () => Logger, loggers, optionalLogger, parentLogger, newLogger, GetService) {
+          this.getLogger = getLogger;
+          this.loggers = loggers;
+          this.optionalLogger = optionalLogger;
+          this.parentLogger = parentLogger;
+          this.newLogger = newLogger;
+          this.GetService = GetService;
+          this.service = new GetService(data);
+        }
+      }
+
+      decorators( Reflect.metadata('design:paramtypes', [()=>Logger, LoggerBase, Logger, Logger, Logger, MyService]) ).on(App);
+      lazy(Logger)(App, null, 0);
+      all(LoggerBase)(App, null, 1);
+      optional()(App, null, 2);
+      parent(App, null, 3);
+      newInstance(Logger, Dependency)(App, null, 4);
+      factory(MyService)(App, null, 5);
+      decorators( autoinject() ).on(App);
+
+      let parentContainer = new Container();
+      let parentInstance = new Logger();
+      parentContainer.registerInstance(Logger, parentInstance);
+
+      let container = parentContainer.createChild();
+      let childInstance = new Logger();
+      container.registerSingleton(LoggerBase, VerboseLogger);
+      container.registerTransient(LoggerBase, Logger);
+      container.registerSingleton(Logger, Logger);
+      container.registerInstance(Logger, childInstance);
+      container.registerSingleton(App, App);
+
+      let app = container.get(App);
+
+      let logger = app.getLogger;
+      expect(logger()).toEqual(jasmine.any(Logger));
+
+      expect(app.loggers).toEqual(jasmine.any(Array));
+      expect(app.loggers.length).toBe(2);
+      expect(app.loggers[0]).toEqual(jasmine.any(VerboseLogger));
+      expect(app.loggers[1]).toEqual(jasmine.any(Logger));
+
+      expect(app.optionalLogger).toEqual(jasmine.any(Logger));
+
+      expect(app.parentLogger).toBe(parentInstance);
+
+      expect(app.newLogger).toEqual(jasmine.any(Logger));
+      expect(app.newLogger).not.toBe(logger);
+      expect(app.newLogger.dep).toEqual(jasmine.any(Dependency));
+
+      let service = app.GetService;
+      expect(service()).toEqual(jasmine.any(MyService));
+      expect(app.service.data).toEqual(data);
     });
   });
 });

--- a/test/container.spec.js
+++ b/test/container.spec.js
@@ -219,54 +219,6 @@ describe('container', () => {
       expect(app2.service).toEqual(jasmine.any(Service));
     });
 
-    it('fail with own static inject', function() {
-      class App {
-        static inject() { return [Container]; }
-        constructor(logger) {
-          this.logger = logger;
-        }
-      }
-      decorators(Reflect.metadata('design:paramtypes', [Logger])).on(App);
-
-      let error = () => decorators( autoinject() ).on(App);
-
-      expect(error).toThrow(jasmine.any(Error));
-
-      /* without the error, autoinject unexpectedly would not do anything
-      /* and following would fail
-
-      decorators( autoinject() ).on(App)
-      let container = new Container();
-
-      let app = container.get(App);
-      expect(app.logger).toEqual(jasmine.any(Logger));
-      expect(app.logger).not.toEqual(jasmine.any(Container));
-      */
-    });
-
-    it('fail with own static inject (and inherited autoinjected inject)', function() {
-      class App {
-        constructor(logger) {
-          this.logger = logger;
-        }
-      }
-      decorators(Reflect.metadata('design:paramtypes', [Logger])).on(App);
-      decorators( autoinject() ).on(App);
-
-      class ChildApp {
-        static inject() { return [App, Logger]; }
-        constructor(app, logger) {
-          this.app = app;
-          this.logger = logger;
-        }
-      }
-      decorators(Reflect.metadata('design:paramtypes', [App, Logger])).on(App);
-
-      let error = () => decorators( autoinject() ).on(ChildApp);
-
-      expect(error).toThrow(jasmine.any(Error));
-    });
-
     describe('with custom resolvers', () => {
       class Dependency {}
       class LoggerBase {
@@ -854,22 +806,6 @@ describe('container', () => {
 
           let logger = app.getLogger;
           expect(logger()).toEqual(jasmine.any(Logger));
-        });
-    
-        it('provides a function which will fail with own static inject', function() {
-          class Logger {}
-
-          class App {
-            static inject() { return [Logger]; }
-            constructor(logger) {
-              this.logger = logger;
-            }
-          }
-          decorators(Reflect.metadata('design:paramtypes', [Logger])).on(App);
-
-          let error = () => lazy(Logger)(App, null, 0);
-
-          expect(error).toThrow(jasmine.any(Error));
         });
       });
 

--- a/test/container.spec.js
+++ b/test/container.spec.js
@@ -219,6 +219,54 @@ describe('container', () => {
       expect(app2.service).toEqual(jasmine.any(Service));
     });
 
+    it('fail with own static inject', function() {
+      class App {
+        static inject() { return [Container]; }
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+      decorators(Reflect.metadata('design:paramtypes', [Logger])).on(App);
+
+      let error = () => decorators( autoinject() ).on(App);
+
+      expect(error).toThrow(jasmine.any(Error));
+
+      /* without the error, autoinject unexpectedly would not do anything
+      /* and following would fail
+
+      decorators( autoinject() ).on(App)
+      let container = new Container();
+
+      let app = container.get(App);
+      expect(app.logger).toEqual(jasmine.any(Logger));
+      expect(app.logger).not.toEqual(jasmine.any(Container));
+      */
+    });
+
+    it('fail with own static inject (and inherited autoinjected inject)', function() {
+      class App {
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+      decorators(Reflect.metadata('design:paramtypes', [Logger])).on(App);
+      decorators( autoinject() ).on(App);
+
+      class ChildApp {
+        static inject() { return [App, Logger]; }
+        constructor(app, logger) {
+          this.app = app;
+          this.logger = logger;
+        }
+      }
+      decorators(Reflect.metadata('design:paramtypes', [App, Logger])).on(App);
+
+      let error = () => decorators( autoinject() ).on(ChildApp);
+
+      expect(error).toThrow(jasmine.any(Error));
+    });
+
     describe('with custom resolvers', () => {
       class Dependency {}
       class LoggerBase {
@@ -806,6 +854,22 @@ describe('container', () => {
 
           let logger = app.getLogger;
           expect(logger()).toEqual(jasmine.any(Logger));
+        });
+    
+        it('provides a function which will fail with own static inject', function() {
+          class Logger {}
+
+          class App {
+            static inject() { return [Logger]; }
+            constructor(logger) {
+              this.logger = logger;
+            }
+          }
+          decorators(Reflect.metadata('design:paramtypes', [Logger])).on(App);
+
+          let error = () => lazy(Logger)(App, null, 0);
+
+          expect(error).toThrow(jasmine.any(Error));
         });
       });
 


### PR DESCRIPTION
The previous fix for autoinject and inheritance compared constructor parameter types with those of the inject property. That broke the  parameter decorators.

This PR reverts autoinject back to the previous assigning of the parameter decorators to static inject by index and just ensures that only the own property 'inject' is used for autoinject and parameter decorators to avoid the inheritance issues. Since the parameter decorators (including inject as parameter decorator) also act as autoinject and manipulate static inject, this was simpified and clarified by letting them use autoinject and rename appropriately.

Included are the fixed test for parameter decorators (including inject) for the use with autoinject, tests for inheritance together with parameter decorators, and a test for the checkparent option of @optional