### PR TITLE
1.5.0

### DIFF
--- a/dist/aurelia-dependency-injection.d.ts
+++ b/dist/aurelia-dependency-injection.d.ts
@@ -80,17 +80,17 @@ export declare class Lazy<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs 
 }
 export declare class All<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>> {
 	constructor(key: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>);
-	get(container: Container): any[];
+	get(container: Container): TImpl[];
 	static of<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>): All<TBase, TImpl, TArgs>;
 }
 export declare class Optional<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>> {
 	constructor(key: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>, checkParent?: boolean);
-	get(container: Container): any;
+	get(container: Container): TImpl;
 	static of<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>, checkParent?: boolean): Optional<TBase, TImpl, TArgs>;
 }
 export declare class Parent<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>> {
 	constructor(key: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>);
-	get(container: Container): any;
+	get(container: Container): TImpl;
 	static of<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>): Parent<TBase, TImpl, TArgs>;
 }
 export declare class Factory<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>> {
@@ -127,14 +127,14 @@ export declare function newInstance<TBase, TImpl extends Impl<TBase> = Impl<TBas
 }, ...dynamicDependencies: TArgs[number][]): (target: DependencyCtor<TBase, TImpl, TArgs> & {
 	inject?: TArgs[number][];
 }, _key: any, index: number) => void;
-export declare function invoker<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(value: Invoker<TBase, TImpl, TArgs>): any;
-export declare function invokeAsFactory(potentialTarget?: any): any;
+export declare function invoker<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(value: Invoker<TBase, TImpl, TArgs>): (target: DependencyCtor<TBase, TImpl, TArgs>) => void;
+export declare function invokeAsFactory<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(potentialTarget?: DependencyCtor<TBase, TImpl, TArgs>): void | ((target: DependencyCtor<TBase, TImpl, TArgs>) => void);
 export interface Invoker<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>> {
 	invoke(container: Container, fn: DependencyCtorOrFunctor<TBase, TImpl, TArgs>, dependencies: TArgs): ImplOrAny<TImpl>;
 	invokeWithDynamicDependencies(container: Container, fn: DependencyCtorOrFunctor<TBase, TImpl, TArgs>, staticDependencies: TArgs[number][], dynamicDependencies: TArgs[number][]): ImplOrAny<TImpl>;
 }
-export declare class FactoryInvoker<TBase = any, TArgs extends Args<TBase> = Args<TBase>, TImpl extends Impl<TBase> = Impl<TBase>> {
-	static instance: FactoryInvoker;
+export declare class FactoryInvoker<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>> implements Invoker<TBase, TImpl, TArgs> {
+	static instance: FactoryInvoker<any>;
 	invoke(container: Container, fn: DependencyCtorOrFunctor<TBase, TImpl, TArgs>, dependencies: TArgs): ImplOrAny<TImpl>;
 	invokeWithDynamicDependencies(container: Container, fn: DependencyCtorOrFunctor<TBase, TImpl, TArgs>, staticDependencies: TArgs[number][], dynamicDependencies: TArgs[number][]): ImplOrAny<TImpl>;
 }
@@ -144,7 +144,7 @@ export declare class InvocationHandler<TBase, TImpl extends Impl<TBase>, TArgs e
 	invoker: Invoker<TBase, TImpl, TArgs>;
 	dependencies: TArgs;
 	constructor(fn: DependencyCtorOrFunctor<TBase, TImpl, TArgs>, invoker: Invoker<TBase, TImpl, TArgs>, dependencies: TArgs);
-	invoke(container: Container, dynamicDependencies?: any[]): any;
+	invoke(container: Container, dynamicDependencies?: TArgs[]): TImpl;
 }
 export interface ContainerConfiguration {
 	onHandlerCreated?: (handler: InvocationHandler<any, any, any>) => InvocationHandler<any, any, any>;
@@ -158,18 +158,19 @@ export declare class Container {
 	makeGlobal(): Container;
 	setHandlerCreatedCallback<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(onHandlerCreated: (handler: InvocationHandler<TBase, TImpl, TArgs>) => InvocationHandler<TBase, TImpl, TArgs>): void;
 	registerInstance<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>, instance?: TImpl): Resolver;
-	registerSingleton<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: any, fn?: DependencyCtorOrFunctor<TBase, TImpl, TArgs>): Resolver;
-	registerTransient<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: string, fn: DependencyCtorOrFunctor<TBase, TImpl, TArgs>): Resolver;
+	registerSingleton<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: Primitive, fn: DependencyCtorOrFunctor<TBase, TImpl, TArgs>): Resolver;
+	registerSingleton<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: DependencyCtor<TBase, TImpl, TArgs>, fn?: DependencyCtorOrFunctor<TBase, TImpl, TArgs>): Resolver;
+	registerTransient<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: Primitive, fn: DependencyCtorOrFunctor<TBase, TImpl, TArgs>): Resolver;
 	registerTransient<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: DependencyCtor<TBase, TImpl, TArgs>, fn?: DependencyCtorOrFunctor<TBase, TImpl, TArgs>): Resolver;
 	registerHandler<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>, handler: (container?: Container, key?: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>, resolver?: Resolver) => any): Resolver;
 	registerAlias<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(originalKey: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>, aliasKey: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>): Resolver;
 	registerResolver<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>, resolver: Resolver): Resolver;
-	autoRegister<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: string, fn: DependencyCtorOrFunctor<TBase, TImpl, TArgs>): Resolver;
+	autoRegister<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: Primitive, fn: DependencyCtorOrFunctor<TBase, TImpl, TArgs>): Resolver;
 	autoRegister<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: DependencyCtor<TBase, TImpl, TArgs>, fn?: DependencyCtorOrFunctor<TBase, TImpl, TArgs>): Resolver;
 	autoRegisterAll(fns: DependencyCtor<any, any, any>[]): void;
 	unregister(key: any): void;
 	hasResolver<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>, checkParent?: boolean): boolean;
-	getResolver<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: PrimitiveOrDependencyCtorOrFunctor<TBase, TImpl, TArgs>): any;
+	getResolver<TStrategyKey extends keyof StrategyState<TBase, TImpl, TArgs>, TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: PrimitiveOrDependencyCtorOrFunctor<TBase, TImpl, TArgs>): StrategyResolver<TBase, TImpl, TArgs, TStrategyKey>;
 	get<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>): ImplOrAny<TImpl>;
 	get<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(key: typeof Container): Container;
 	_get(key: any): any;
@@ -182,8 +183,8 @@ export declare class Container {
 }
 export declare function autoinject(potentialTarget?: DependencyCtor<any, any, any>): any;
 export declare function inject<TBase, TImpl extends Impl<TBase> = Impl<TBase>, TArgs extends Args<TBase> = Args<TBase>>(...rest: TArgs[number][]): any;
-export declare function registration<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(value: Registration<TBase, TImpl, TArgs>): any;
-export declare function transient<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(key?: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>): any;
+export declare function registration<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(value: Registration<TBase, TImpl, TArgs>): (target: DependencyCtor<TBase, TImpl, TArgs>) => void;
+export declare function transient<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(key?: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>): (target: DependencyCtor<TBase, TImpl, TArgs>) => void;
 export declare function singleton(registerInChild?: boolean): any;
 export declare function singleton<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(key?: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>, registerInChild?: boolean): any;
 export interface Registration<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>> {

--- a/dist/es2015/aurelia-dependency-injection.js
+++ b/dist/es2015/aurelia-dependency-injection.js
@@ -511,7 +511,7 @@ function invoker(value) {
     };
 }
 function invokeAsFactory(potentialTarget) {
-    const deco = target => {
+    const deco = (target) => {
         metadata.define(metadata.invoker, FactoryInvoker.instance, target);
     };
     return potentialTarget ? deco(potentialTarget) : deco;

--- a/dist/es2017/aurelia-dependency-injection.js
+++ b/dist/es2017/aurelia-dependency-injection.js
@@ -511,7 +511,7 @@ function invoker(value) {
     };
 }
 function invokeAsFactory(potentialTarget) {
-    const deco = target => {
+    const deco = (target) => {
         metadata.define(metadata.invoker, FactoryInvoker.instance, target);
     };
     return potentialTarget ? deco(potentialTarget) : deco;

--- a/dist/umd-es2015/aurelia-dependency-injection.js
+++ b/dist/umd-es2015/aurelia-dependency-injection.js
@@ -514,7 +514,7 @@
       };
   }
   function invokeAsFactory(potentialTarget) {
-      const deco = target => {
+      const deco = (target) => {
           aureliaMetadata.metadata.define(aureliaMetadata.metadata.invoker, FactoryInvoker.instance, target);
       };
       return potentialTarget ? deco(potentialTarget) : deco;

--- a/src/invokers.ts
+++ b/src/invokers.ts
@@ -2,14 +2,14 @@
 /// <reference path="./internal.ts" />
 import { metadata } from 'aurelia-metadata';
 import { Container } from './container';
-import { DependencyCtorOrFunctor, ImplOrAny, Impl, Args } from './types';
+import { DependencyCtorOrFunctor, ImplOrAny, Impl, Args, DependencyCtor } from './types';
 
 /**
  * Decorator: Specifies a custom Invoker for the decorated item.
  */
 export function invoker<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(
   value: Invoker<TBase, TImpl, TArgs>
-): any {
+): (target: DependencyCtor<TBase, TImpl, TArgs>) => void {
   return target => {
     metadata.define(metadata.invoker, value, target);
   };
@@ -19,8 +19,10 @@ export function invoker<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBa
  * Decorator: Specifies that the decorated item should be called as a factory
  * function, rather than a constructor.
  */
-export function invokeAsFactory(potentialTarget?: any): any {
-  const deco = target => {
+export function invokeAsFactory<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(
+  potentialTarget?: DependencyCtor<TBase, TImpl, TArgs>
+): void | ((target: DependencyCtor<TBase, TImpl, TArgs>) => void) {
+  const deco = (target: DependencyCtor<TBase, TImpl, TArgs>) => {
     metadata.define(metadata.invoker, FactoryInvoker.instance, target);
   };
 
@@ -63,14 +65,14 @@ export interface Invoker<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TB
  * An Invoker that is used to invoke a factory method.
  */
 export class FactoryInvoker<
-  TBase = any,
-  TArgs extends Args<TBase> = Args<TBase>,
-  TImpl extends Impl<TBase> = Impl<TBase>
-  > {
+  TBase,
+  TImpl extends Impl<TBase> = Impl<TBase>,
+  TArgs extends Args<TBase> = Args<TBase>
+  > implements Invoker<TBase, TImpl, TArgs> {
   /**
    * The singleton instance of the FactoryInvoker.
    */
-  public static instance: FactoryInvoker;
+  public static instance: FactoryInvoker<any>;
 
   /**
    * Invokes the function with the provided dependencies.

--- a/src/registrations.ts
+++ b/src/registrations.ts
@@ -7,7 +7,8 @@ import {
   DependencyCtorOrFunctor,
   PrimitiveOrDependencyCtor,
   Impl,
-  Args
+  Args,
+  DependencyCtor
 } from './types';
 
 /**
@@ -15,8 +16,8 @@ import {
  * class/function.
  */
 export function registration<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(
-  value: Registration<TBase, TImpl, TArgs>): any {
-  return (target: (...rest: any[]) => any) => {
+  value: Registration<TBase, TImpl, TArgs>) {
+  return (target: DependencyCtor<TBase, TImpl, TArgs>) => {
     metadata.define(metadata.registration, value, target);
   };
 }
@@ -26,7 +27,7 @@ export function registration<TBase, TImpl extends Impl<TBase>, TArgs extends Arg
  * lifetime.
  */
 export function transient<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(
-  key?: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>): any {
+  key?: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>) {
   return registration(new TransientRegistration<TBase, TImpl, TArgs>(key));
 }
 
@@ -34,9 +35,9 @@ export function transient<TBase, TImpl extends Impl<TBase>, TArgs extends Args<T
  * Decorator: Specifies to register the decorated item with a "singleton"
  * lifetime.
  */
-export function singleton(registerInChild?: boolean): any;
+export function singleton(registerInChild?: boolean);
 export function singleton<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(
-  key?: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>, registerInChild?: boolean): any;
+  key?: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs>, registerInChild?: boolean);
 export function singleton<TBase, TImpl extends Impl<TBase>, TArgs extends Args<TBase>>(
   keyOrRegisterInChild?: PrimitiveOrDependencyCtor<TBase, TImpl, TArgs> | boolean, registerInChild: boolean = false) {
   return registration<TBase, TImpl, TArgs>(

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -216,7 +216,7 @@ export class All<TBase,
    * @param container The container to resolve from.
    * @return Returns an array of all matching instances.
    */
-  public get(container: Container): any[] {
+  public get(container: Container): TImpl[] {
     return container.getAll(this._key);
   }
 
@@ -264,7 +264,7 @@ export class Optional<TBase,
    * @param container The container to resolve from.
    * @return Returns the instance if found; otherwise null.
    */
-  public get(container: Container): any {
+  public get(container: Container): TImpl {
     if (container.hasResolver(this._key, this._checkParent)) {
       return container.get(this._key);
     }
@@ -312,7 +312,7 @@ export class Parent<TBase,
    * @param container The container to resolve the parent from.
    * @return Returns the matching instance from the parent container
    */
-  public get(container: Container): any {
+  public get(container: Container): TImpl {
     return container.parent ? container.parent.get(this._key) : null;
   }
 


### PR DESCRIPTION
As per @fkleuver all these changes I've been making have been breaking changes. So I fixed up the last of the outward facing apis to give consistent typings throughout (to not need to have any more breaking changes surrounding typings) and bumped the major version.

Unless you have other plans for 2.0.0 e.g. runtime breaking changes, I'm comfortable with creating a release for these changes with this PR. Let me know if you'd like some more eyes on these changes.