### PR TITLE
Failing tests for #197

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 
 # Unix-style newlines with a newline ending every file
 [*]
-end_of_line = crlf
+end_of_line = lf
 insert_final_newline = true
 
 # 2 space indentation

--- a/test/resolver.spec.ts
+++ b/test/resolver.spec.ts
@@ -426,6 +426,26 @@ describe('resolver', () => {
 
       class Dependency { }
 
+      it('get a new instance of a dependency, without regard for existing instances in the container', () => {
+        const container = new Container();
+        const logger = container.get(Logger);
+        const newLogger = container.get(NewInstance.of(Logger));
+
+        expect(logger).toEqual(jasmine.any(Logger));
+        expect(newLogger).toEqual(jasmine.any(Logger));
+        expect(newLogger).not.toBe(logger);
+      });
+
+      it('new instance of a dependency does not become the default instance in the container', () => {
+        const container = new Container();
+        const newLogger = container.get(NewInstance.of(Logger));
+        const logger = container.get(Logger);
+
+        expect(logger).toEqual(jasmine.any(Logger));
+        expect(newLogger).toEqual(jasmine.any(Logger));
+        expect(newLogger).not.toBe(logger);
+      });
+
       it('inject a new instance of a dependency, without regard for existing instances in the container', () => {
         class App1 {
           public static inject() { return [NewInstance.of(Logger)]; }
@@ -434,8 +454,8 @@ describe('resolver', () => {
         }
 
         const container = new Container();
-        const logger = container.get(Logger);
         const app1 = container.get(App1);
+        const logger = container.get(Logger);
 
         expect(app1.logger).toEqual(jasmine.any(Logger));
         expect(app1.logger).not.toBe(logger);
@@ -449,11 +469,108 @@ describe('resolver', () => {
         }
 
         const container = new Container();
-        const logger = container.get(Logger);
         const app1 = container.get(App1);
+        const logger = container.get(Logger);
 
         expect(app1.logger).toEqual(jasmine.any(Logger));
         expect(app1.logger).not.toBe(logger);
+      });
+
+      it('decorate with inject(NewInstance.of()) to inject a new instance of a dependency', () => {
+        type ILogger = Logger;
+
+        @autoinject
+        class App1 {
+          constructor(
+            @inject(NewInstance.of(Logger)) public logger: ILogger,
+          ) {
+          }
+        }
+
+        const container = new Container();
+        const app1 = container.get(App1);
+        const logger = container.get(Logger);
+
+        expect(app1.logger).toEqual(jasmine.any(Logger));
+        expect(app1.logger).not.toBe(logger);
+      });
+
+      it('decorate with inject(NewInstance.of()) to inject a new instance of a dependency (inject default elsewhere)',
+        () => {
+          type ILogger = Logger;
+
+          @autoinject
+          class Child {
+            constructor(
+              public logger: Logger,
+            ) { }
+          }
+
+          @autoinject
+          class App1 {
+            constructor(
+              @inject(NewInstance.of(Logger)) public logger: ILogger,
+              public child: Child,
+            ) {
+            }
+          }
+
+          const container = new Container();
+          const app1 = container.get(App1);
+          const logger = container.get(Logger);
+
+          expect(app1.logger).toEqual(jasmine.any(Logger));
+          expect(app1.logger).not.toBe(logger);
+        });
+
+      it('decorate to inject a new instance of a dependency (inject default elsewhere)', () => {
+        @autoinject
+        class Child {
+          constructor(
+            public logger: Logger,
+          ) { }
+        }
+
+        @autoinject
+        class App1 {
+          constructor(
+            @newInstance() public logger: Logger,
+            public child: Child,
+          ) {
+          }
+        }
+
+        const container = new Container();
+        const app1 = container.get(App1);
+        const logger = container.get(Logger);
+
+        expect(app1.logger).toEqual(jasmine.any(Logger));
+        expect(app1.logger).not.toBe(logger);
+      });
+
+      it('default instance can be injected when newInstance injected in parent', () => {
+        @autoinject
+        class Child {
+          constructor(
+            public logger: Logger,
+          ) { }
+        }
+
+        @autoinject
+        class App1 {
+          constructor(
+            @newInstance() public logger: Logger,
+            public child: Child,
+          ) {
+          }
+        }
+
+        const container = new Container();
+        const app1 = container.get(App1);
+        const logger = container.get(Logger);
+
+        expect(app1.child).toEqual(jasmine.any(Child));
+        expect(app1.child.logger).toBe(logger);
       });
 
       it('decorate to inject a new instance of a dependency under a new key', () => {
@@ -464,8 +581,8 @@ describe('resolver', () => {
         }
 
         const container = new Container();
-        const logger = container.get<string, Logger>('akey');
         const app1 = container.get(App1);
+        const logger = container.get<string, Logger>('akey');
 
         expect(app1.logger).toEqual(jasmine.any(Logger));
         expect(app1.logger).not.toEqual(logger);
@@ -479,8 +596,8 @@ describe('resolver', () => {
         }
 
         const container = new Container();
-        const logger = container.get(Logger);
         const app1 = container.get(App1);
+        const logger = container.get(Logger);
 
         expect(app1.logger).toEqual(jasmine.any(Logger));
         expect(app1.logger).not.toBe(logger);
@@ -495,8 +612,8 @@ describe('resolver', () => {
         }
 
         const container = new Container();
-        const logger = container.get(Logger);
         const app1 = container.get(App1);
+        const logger = container.get(Logger);
 
         expect(app1.logger).toEqual(jasmine.any(Logger));
         expect(app1.logger).not.toBe(logger);
@@ -511,8 +628,8 @@ describe('resolver', () => {
         }
 
         const container = new Container();
-        const logger = container.get(Logger);
         const app1 = container.get(App1);
+        const logger = container.get(Logger);
 
         expect(app1.logger).toEqual(jasmine.any(Logger));
         expect(app1.logger).not.toBe(logger);
@@ -526,8 +643,8 @@ describe('resolver', () => {
         }
 
         const container = new Container();
-        const logger = container.get(Logger);
         const app1 = container.get(App1);
+        const logger = container.get(Logger);
 
         expect(app1.logger).toEqual(jasmine.any(Logger));
         expect(app1.logger).not.toBe(logger);


### PR DESCRIPTION
https://github.com/aurelia/dependency-injection/issues/197

I started by adding some tests that were more similar to my actual use case
 before realizing the actual difference between the working tests and the failing case.

The distilled failing test case here is:
 `new instance of a dependency does not become the default instance in the container`

For the existing tests, swapping the order of getting App1 and Logger causes all of the NewInstance tests to fail.

PR is just for info purposes unless you want to add these extra tests.
Also, my editor kept changing line endings to CRLF, realized the wrong value was in .editorconfig